### PR TITLE
Meta ent full spec

### DIFF
--- a/bin/genMeta.sh
+++ b/bin/genMeta.sh
@@ -442,22 +442,25 @@ $NIX eval --impure $EXTRA_NIX_FLAGS $OUT_TYPE  \
     in builtins.mapAttrs ( _: prepEnt ) base;
 
     # Add metadata about the node_modules/ tree.
-    trees = let
-      mkTree = dev: lib.libtree.idealTreePlockV3 {
-        inherit lockDir dev metaSet;
-        skipUnsupported = false;
+    rootEntWithTrees = {
+      ${metaSet._meta.rootKey} = serial.${metaSet._meta.rootKey} // {
+        treeInfo = let
+          mkTree = dev: lib.libtree.idealTreePlockV3 {
+            inherit lockDir dev metaSet;
+            skipUnsupported = false;
+          };
+          maybeDev = lib.optionalAttrs isDev { dev = mkTree true; };
+        in { prod = mkTree false; } // maybeDev;
       };
-      maybeDev = lib.optionalAttrs isDev { dev = mkTree true; };
-    in { prod = mkTree false; } // maybeDev;
+    };
 
     # Stash extra info in an "internal" attribute
     _meta  = {
       inherit (metaSet._meta) fromType rootKey;
-      inherit trees;
     };
 
     # Finalize data to be written
-    data = serial // { inherit _meta; };
+    data = serial // rootEntWithTrees // { inherit _meta; };
 
     # For Nix output put a header at the top of the file with instructions
     # on how to regenerate.

--- a/doc/metaEnt.org
+++ b/doc/metaEnt.org
@@ -109,26 +109,11 @@ Entry Fields
 *** publish
 *** install
 
-** treeInfo
-:PROPERTIES:
-:Optional: true
-:DerivedFrom: metaFiles.plock | metaFiles.trees
-:END:
-*** dev
-:PROPERTIES:
-:Type: attrs<key>
-:Default: {}
-:END:
-*** prod
-:PROPERTIES:
-:Type: attrs<key>
-:Default: {}
-:END:
-
 ** sysInfo
 :PROPERTIES:
 :Optional: false
 :DerivedFrom: metaFiles.pjs | metaFiles.plent
+:Default: {}
 :END:
 *** cpu
 :PROPERTIES:
@@ -146,6 +131,22 @@ Entry Fields
 :Default: null
 :END:
 **** node
+
+** treeInfo
+:PROPERTIES:
+:Optional: true
+:DerivedFrom: metaFiles.plock | metaFiles.trees
+:END:
+*** dev
+:PROPERTIES:
+:Type: attrs<key>
+:Default: {}
+:END:
+*** prod
+:PROPERTIES:
+:Type: attrs<key>
+:Default: {}
+:END:
 
 ** metaFiles
 :PROPERTIES:
@@ -166,25 +167,21 @@ Entry Fields
 *** vinfo
 *** packument
 
-*** trees
-**** dev
-**** prod
-
 ** fsInfo
 :PROPERTIES:
 :Optional: true
-:DerivedFrom: sourceInfo
 :Default: null
 :END:
 *** gypfile
 :PROPERTIES:
 :Type: bool
+:DerivedFrom: sourceInfo
 :Default: false
 :END:
 *** dir
 :PROPERTIES:
 :Type: relpath
-:Default: "./."
+:Default: "."
 :END:
 directory relative to =sourceInfo= where =package.json= is located.
 

--- a/doc/metaEnt.org
+++ b/doc/metaEnt.org
@@ -4,35 +4,62 @@
 ** key
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: ident version
+:Default: "@floco/phony/0.0.0-missing"
 :END:
 
 ** ident
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: metaFiles.plent | metaFiles.pjs
+:Default: "@floco/phony"
 :END:
 
 ** version
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: metaFiles.plent | metaFiles.pjs
+:Default: "0.0.0-missing"
 :END:
 
 ** entFromtype
 :PROPERTIES:
 :Optional: false
+:Default: "raw"
 :END:
 
 ** ltype
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: fetchInfo | metaFiles.plent
 :END:
-One of:
-- file
-- dir
-- git
+NPM _lifecycle type_, or "source type".
+This field dictates the availability of certain lifecycle events such that
+it may cause scripts declared in =package.json= to be ignored in some cases.
+
+- One of:
+  + file
+  + dir
+  + git
+  + link
+- =file= lifecycle types are associated with distributed tarballs - this
+  =ltype= will not run =build=, =prepare=, or =publish=
+  events when processed for consumption ( only =install= is run ).
+- =git= lifecycle types have =devDependencies= available when processing
+  =prepublish= events, while other lifecycle types do not.
+- =link= lifecycle types are processed very differently by this framework
+  than they are with NPM.
+  Please refer to the [[file:../lib/events.nix][libevent]] docs for details.
+- =dir= lifecycle types almost always refer to the "target" project in the
+  context of a given build.
+  + A =keyTree= style attrset should contain no more than one =dir= entry in
+    most cases.
 
 ** binInfo
 :PROPERTIES:
 :Optional: true
+:DerivedFrom: metaFiles.pjs fsInfo | metaFiles.plent
+:Default: null
 :END:
 *** binPairs
 *** binDir
@@ -40,7 +67,10 @@ One of:
 ** depInfo
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: metaFiles.pjs | metaFiles.plent
+:Default: {}
 :END:
+Entry Fields
 *** descriptor
 *** runtime
 *** dev
@@ -51,6 +81,7 @@ One of:
 ** fetchInfo
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: metaFiles.plent
 :END:
 *** type
 *** narHash
@@ -69,6 +100,7 @@ One of:
 ** lifecycle
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: fsInfo metaFiles.pjs ltype | metaFiles.plent metaFiles.pjs
 :END:
 *** build
 *** prepare
@@ -80,21 +112,46 @@ One of:
 ** treeInfo
 :PROPERTIES:
 :Optional: true
+:DerivedFrom: metaFiles.plock | metaFiles.trees
 :END:
-*** keyTree
+*** dev
+:PROPERTIES:
+:Type: attrs<key>
+:Default: {}
+:END:
+*** prod
+:PROPERTIES:
+:Type: attrs<key>
+:Default: {}
+:END:
 
 ** sysInfo
 :PROPERTIES:
 :Optional: false
+:DerivedFrom: metaFiles.pjs | metaFiles.plent
 :END:
 *** cpu
+:PROPERTIES:
+:Type: list<cpu[npm]>
+:Default: null
+:END:
 *** os
+:PROPERTIES:
+:Type: list<os[npm]>
+:Default: null
+:END:
 *** engines
+:PROPERTIES:
+:Type: attrs<descriptor>
+:Default: null
+:END:
 **** node
 
 ** metaFiles
 :PROPERTIES:
 :Optional: true
+:Serialized: false
+:Default: {}
 :END:
 *** pjsDir
 *** lockDir
@@ -116,17 +173,45 @@ One of:
 ** fsInfo
 :PROPERTIES:
 :Optional: true
+:DerivedFrom: sourceInfo
+:Default: null
 :END:
 *** gypfile
+:PROPERTIES:
+:Type: bool
+:Default: false
+:END:
 *** dir
+:PROPERTIES:
+:Type: relpath
+:Default: "./."
+:END:
 directory relative to =sourceInfo= where =package.json= is located.
 
 ** sourceInfo
 :PROPERTIES:
 :Optional: true
+:DerivedFrom: fetchInfo
+:Default: null
 :END:
+A directory in the Nix Store containing the module.
+This directory must have =package.json= at its top-level,
+or ~${fsInfo.dir}/package.json~.
 
-** treeInfo
+- Pure libs can produce =sourceInfo= from =fetchInfo= if the fetcher
+  produces a directory in the Nix Store in most cases.
+- Tarballs with incorrect directory permissions prevent us from unpacking a
+  relatively small number of tarballs using ~builtins.fetchTree~ or
+  ~builtins.fetchTarball~, meaning we would require IFD to produce a
+  =sourceInfo= field.
+- When =fsInfo.dir= is set, =sourceInfo= in the =metaEnt= may differ from
+  the =outPath= found in the =pkgEnt:source= record.
+
+** names
 :PROPERTIES:
-:Optional: true
+:Optional: false
+:DerivedFrom: name version | key
+:Serialized: false
 :END:
+This attrset is derived and should not be set by the user unless you are
+intentionally trying to override names.

--- a/doc/metaEnt.org
+++ b/doc/metaEnt.org
@@ -105,7 +105,7 @@ One of:
 *** pjs
 *** plock
 *** plent
-**** pkey
+*** plentKey
 *** vinfo
 *** packument
 

--- a/doc/metaEnt.org
+++ b/doc/metaEnt.org
@@ -5,7 +5,7 @@
 :PROPERTIES:
 :Optional: false
 :DerivedFrom: ident version
-:Default: "@floco/phony/0.0.0-missing"
+:Default: "@floco/phony/0.0.0-none"
 :END:
 
 ** ident
@@ -19,7 +19,7 @@
 :PROPERTIES:
 :Optional: false
 :DerivedFrom: metaFiles.plent | metaFiles.pjs
-:Default: "0.0.0-missing"
+:Default: "0.0.0-none"
 :END:
 
 ** entFromtype
@@ -154,17 +154,21 @@ Entry Fields
 :Serialized: false
 :Default: {}
 :END:
-*** pjsDir
-*** lockDir
-*** vinfoUrl
-*** packumentUrl
-
 *** metaRaw
+
+*** pjsDir
 *** pjs
+*** pjsKey
+
+*** lockDir
 *** plock
 *** plent
 *** plentKey
+
+*** vinfoUrl
 *** vinfo
+
+*** packumentUrl
 *** packument
 
 ** fsInfo

--- a/doc/metaEnt.org
+++ b/doc/metaEnt.org
@@ -1,0 +1,127 @@
+#+TITLE: Meta Ent
+
+* Fields
+** key
+:PROPERTIES:
+:Optional: false
+:END:
+
+** ident
+:PROPERTIES:
+:Optional: false
+:END:
+
+** version
+:PROPERTIES:
+:Optional: false
+:END:
+
+** entFromtype
+:PROPERTIES:
+:Optional: false
+:END:
+
+** ltype
+:PROPERTIES:
+:Optional: false
+:END:
+One of:
+- file
+- dir
+- git
+
+** binInfo
+:PROPERTIES:
+:Optional: true
+:END:
+*** binPairs
+*** binDir
+
+** depInfo
+:PROPERTIES:
+:Optional: false
+:END:
+*** descriptor
+*** runtime
+*** dev
+*** optional
+*** peer
+*** peerDescriptor
+
+** fetchInfo
+:PROPERTIES:
+:Optional: false
+:END:
+*** type
+*** narHash
+
+*** url
+*** unpack
+
+*** path
+*** basedir
+*** recursive
+
+*** owner
+*** repo
+*** rev
+
+** lifecycle
+:PROPERTIES:
+:Optional: false
+:END:
+*** build
+*** prepare
+*** pack
+*** test
+*** publish
+*** install
+
+** treeInfo
+:PROPERTIES:
+:Optional: true
+:END:
+*** keyTree
+
+** sysInfo
+:PROPERTIES:
+:Optional: false
+:END:
+*** cpu
+*** os
+*** engines
+**** node
+
+** metaFiles
+:PROPERTIES:
+:Optional: true
+:END:
+*** pjsDir
+*** lockDir
+*** vinfoUrl
+*** packumentUrl
+
+*** metaRaw
+*** pjs
+*** plock
+*** plent
+**** pkey
+*** vinfo
+*** packument
+
+*** trees
+**** dev
+**** prod
+
+** fsInfo
+:PROPERTIES:
+:Optional: true
+:END:
+*** gypfile
+*** dir
+directory relative to =sourceInfo= where =package.json= is located.
+
+** sourceInfo
+:PROPERTIES:
+:Optional: true
+:END:

--- a/doc/metaEnt.org
+++ b/doc/metaEnt.org
@@ -125,3 +125,8 @@ directory relative to =sourceInfo= where =package.json= is located.
 :PROPERTIES:
 :Optional: true
 :END:
+
+** treeInfo
+:PROPERTIES:
+:Optional: true
+:END:

--- a/lib/bin-info.nix
+++ b/lib/bin-info.nix
@@ -1,0 +1,75 @@
+# ============================================================================ #
+#
+#
+#
+# ---------------------------------------------------------------------------- #
+
+{ lib }: let
+
+  yt = lib.ytypes // lib.ytypes.Core // lib.ytypes.Prim;
+
+# ---------------------------------------------------------------------------- #
+
+  binInfoFromMetaFiles' = { typecheck, ... } @ fenv: metaEnt: let
+    mfs      = lib.libmeta.getMetaFiles metaEnt;
+    haveInfo = ( mfs ? metaRaw.binInfo ) || ( mfs ? plent ) || ( mfs ? pjs );
+    binDir   = mfs.plent.directories.bin or mfs.pjs.directories.bin or null;
+    binDir'  = if binDir == null then {} else { inherit binDir; };
+    bins     = mfs.plent.bin or mfs.pjs.bin or {};
+    bins'    = if bins == null then {} else {
+      binPairs = if builtins.isAttrs bins then bins else {
+        ${metaEnt.names.bname} = bins;
+      };
+    };
+    rsl = if ! haveInfo then null else
+          if mfs ? metaRaw.binInfo then metaEnt.metaRaw.binInfo else
+          binDir' // bins';
+  in if typecheck
+     then ( yt.either yt.nil yt.FlocoMeta.bin_info ) rsl
+     else rsl;
+
+
+# ---------------------------------------------------------------------------- #
+
+  binInfoFromMetaFilesOv' = { typecheck, ... } @ fenv: let
+    fn = binInfoFromMetaFiles' fenv;
+  in final: prev: if ( fn prev ) == null then {} else {
+    binInfo = fn prev;
+  };
+
+
+# ---------------------------------------------------------------------------- #
+
+  _fenvFns = {
+    inherit
+      binInfoFromMetaFiles'
+      binInfoFromMetaFilesOv'
+    ;
+  };
+
+
+# ---------------------------------------------------------------------------- #
+
+in {
+
+  inherit
+    binInfoFromMetaFiles'
+    binInfoFromMetaFilesOv'
+  ;
+
+  __withFenv = fenv: let
+    cw  = builtins.mapAttrs ( _: lib.callWith fenv ) _fenvFns;
+    app = let
+      proc = acc: name: acc // {
+        ${lib.yank "(.*)'" name} = lib.apply _fenvFns.${name} fenv;
+      };
+    in builtins.foldl' proc {} ( builtins.attrNames _fenvFns );
+  in cw // app;
+
+}
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/lib/depinfo.nix
+++ b/lib/depinfo.nix
@@ -110,15 +110,17 @@
   depInfoEntFromPlockV3 = path: plent: let
     markField = field: builtins.mapAttrs ( _: _: { ${field} = true; } );
     cds = builtins.mapAttrs ( _: v: { descriptor = v; } ) ( joinPins plent );
+    peerEnts =
+      ( builtins.mapAttrs ( _: _: "*" ) ( plent.peerDependenciesMeta or {} ) )
+      // ( plent.peerDependencies or {} );
     # Some dependencies may be `peer' and `runtime' but have different
     # descriptors, so we record these with distinct names.
     # This matters if we expect to produce overlays which mix locks.
     # NOTE: A lot of packages have conflicting descriptors this matters.
-    pds = builtins.mapAttrs ( _: v: { peerDescriptor = v; } )
-                            ( plent.peerDependencies or {} );
+    pds      = builtins.mapAttrs ( _: v: { peerDescriptor = v; } ) peerEnts;
     markRt   = markField "runtime" ( joinRt plent );
     markDev  = markField "dev"     ( plent.devDependencies or {} );
-    markPeer = markField "peer"    ( plent.peerDependencies or {} );
+    markPeer = markField "peer"    peerEnts;
     # TODO: `devDependenciesMeta' is used by Yarn
     markOpt  = let
       od = markField "optional" ( plent.optionalDependencies or {} );

--- a/lib/events.nix
+++ b/lib/events.nix
@@ -181,6 +181,7 @@
           proc = acc: p:
             if acc == true then acc else
             if acc == null then p else
+            if p == null then acc else
             acc || p;
           checks = [
             ( final.gypfile or null )

--- a/lib/events.nix
+++ b/lib/events.nix
@@ -160,52 +160,21 @@
 
 # ---------------------------------------------------------------------------- #
 
-  # FIXME: disconnected from `hasInstallScript'
-  metaEntLifecycleOverlay = final: prev: {
-    lifecycle = let
-      flt = ( eventsForLifecycleStrict' final.ltype ) // {
-        build = final.ltype != "file";
-      };
-      scripts = lib.libmeta.getScripts final;
-      ifdef = if scripts == null then {} else {
-        build   = lib.libpkginfo.hasBuildFromScripts scripts;
-        prepare = lib.libpkginfo.hasPrepareFromScripts scripts;
-        pack    = lib.libpkginfo.hasPackFromScripts scripts;
-        test    = lib.libpkginfo.hasTestFromScripts scripts;
-        publish = lib.libpkginfo.hasPublishFromScripts scripts;
-        install = lib.libpkginfo.hasInstallFromScripts scripts;
-      };
-      # These are special and need to be set to `null' if we aren't sure.
-      hi' = {
-        install = let
-          proc = acc: p:
-            if acc == true then acc else
-            if acc == null then p else
-            if p == null then acc else
-            acc || p;
-          checks = [
-            ( lib.libmeta.getGypfile final )
-            ( final.metaFiles.plock.hasInstallScript or null )
-            ( ifdef.install or null )
-          ];
-          has = builtins.foldl' proc null checks;
-        in if flt.install == null then has else
-           if has == null then flt.install else flt.install && has;
-      };
-      proc = acc: event: acc // { ${event} = flt.${event} && ifdef.${event}; };
-      base = builtins.foldl' proc {} ( builtins.attrNames ifdef );
-      fromPartial =
-        if ( prev.lifecycle or null ) == null then {} else {
-          build   = prev.lifecycle.build or false;
-          prepare = prev.lifecycle.prepared or false;
-          pack    = prev.lifecycle.pack or false;
-          test    = prev.lifecycle.test or false;
-          publish = prev.lifecycle.publish or false;
-          install = if ( prev.lifecycle.install or false ) == null
-                    then hi'.install
-                    else prev.lifecycle.install or false;
-        };
-    in base // hi' // fromPartial;
+  metaEntLifecycleOv = final: prev: {
+    lifecycle = {
+      install =
+        if prev ? metaFiles.plent then
+          prev.metaFiles.plent.hasInstallScript or false
+        else if prev ? metaFiles.pjs then
+          lib.libpkginfo.hasInstallFromScripts ( lib.libmeta.getScripts prev )
+        else lib.libmeta.getGypfile prev;
+      build =
+        if ( lib.libmeta.getLtype prev ) == "file" then false else
+        if ( lib.libmeta.getScripts prev ) == null then null else
+        ( lib.libpkginfo.hasBuildFromScripts ( lib.libmeta.getScripts prev ) );
+    } // ( lib.filterAttrs ( _: v: v != null )
+                           ( ( prev.metaFiles.metaRaw.lifecycle or {} ) //
+                             ( prev.lifecycle or {} ) ) );
   };
 
 
@@ -218,7 +187,7 @@ in {
     eventHooksForLtype' eventHooksForLtype
 
     eventsForLifecycleStrict'
-    metaEntLifecycleOverlay
+    metaEntLifecycleOv
   ;
 
 }

--- a/lib/events.nix
+++ b/lib/events.nix
@@ -185,7 +185,6 @@
             acc || p;
           checks = [
             ( final.gypfile or null )
-            ( final.hasInstallScript or null )
             ( final.metaFiles.plock.hasInstallScript or null )
             ( ifdef.install or null )
           ];

--- a/lib/events.nix
+++ b/lib/events.nix
@@ -184,12 +184,13 @@
             if p == null then acc else
             acc || p;
           checks = [
-            ( final.gypfile or null )
+            ( lib.libmeta.getGypfile final )
             ( final.metaFiles.plock.hasInstallScript or null )
             ( ifdef.install or null )
           ];
           has = builtins.foldl' proc null checks;
-        in flt.install && has;
+        in if flt.install == null then has else
+           if has == null then flt.install else flt.install && has;
       };
       proc = acc: event: acc // { ${event} = flt.${event} && ifdef.${event}; };
       base = builtins.foldl' proc {} ( builtins.attrNames ifdef );

--- a/lib/fpkgs.nix
+++ b/lib/fpkgs.nix
@@ -61,7 +61,7 @@
     inner = fpkg: let
       pt = fpkg.passthru.metaEnt;
     in if yt.FlocoMeta.meta_ent_shallow.check pt then pt else
-       lib.libmeta.metaEntFromRaw' fenv pt;
+       lib.libmeta.mkMetaEnt pt;
   in inner;
 
 

--- a/lib/fpkgs.nix
+++ b/lib/fpkgs.nix
@@ -61,7 +61,7 @@
     inner = fpkg: let
       pt = fpkg.passthru.metaEnt;
     in if yt.FlocoMeta.meta_ent_shallow.check pt then pt else
-       lib.libmeta.metaEntFromSerial' fenv pt;
+       lib.libmeta.metaEntFromRaw' fenv pt;
   in inner;
 
 

--- a/lib/meta-ent.nix
+++ b/lib/meta-ent.nix
@@ -27,173 +27,41 @@
 
 # ---------------------------------------------------------------------------- #
 
+  getKey     = { key, ... }: yt.FlocoMeta._meta_ent_info_fields.key key;
+  getIdent   = { ident, ... }: yt.FlocoMeta._meta_ent_info_fields.ident ident;
+  getVersion = { version, ... }:
+    yt.FlocoMeta._meta_ent_info_fields.version version;
+
+  getEntFromtype = { entFromtype, ... }:
+    yt.FlocoMeta._meta_ent_info_fields.entFromtype entFromtype;
+
+  getLtype = { ltype, ... }: yt.FlocoMeta._meta_ent_info_fields.ltype ltype;
+
   # original metadata sources such as `package.json' are stashed as members
   # of `metaFiles' by default.
   # We use this accessor to refer to them so that users can override this
   # function with custom implementations that fetch these files.
   # TODO: deprecate `entries' field.
   getMetaFiles = {
-    entries   ? {}
-  , metaFiles ? {}
+    metaFiles ? {}
   , ...
-  } @ args: let
-    msg =
-      "WARNING: <META-ENT>.entries.* is deprecated. Use <META-ENT>.metaFiles.*";
-    pull = attrs: builtins.attrValues ( removeAttrs attrs ["__serial"] );
-  in if args ? entries then builtins.trace msg ( pull entries )
-                       else pull metaFiles;
+  } @ args: metaFiles;
 
   # Abstraction to refer to `package.json' scripts fields.
   getScripts = {
-    scripts ? null
+    metaFiles ? {}
   , ...
   } @ args: let
-    mfs            = builtins.filter builtins.isAttrs ( getMetaFiles args );
-    fromMetaFiles  = builtins.catAttrs "scripts" mfs;
-    mergeMetaFiles =
-      ( builtins.foldl' ( a: b: a // b ) {} fromMetaFiles ) //
-      ( args.scripts or {} );
-  in if ( scripts == null ) && ( mfs == [] ) then null else
-     if mfs != [] then mergeMetaFiles else scripts;
+  in if ! ( metaFiles ? pjs ) then null else
+     metaFiles.pjs.scripts or {};
 
-
-# ---------------------------------------------------------------------------- #
-
-  entHasStageScript = stage: ent: let
-    scripts = ent.scripts or ( getScripts ent );
-  in lib.libpkginfo.hasStageFromScripts stage scripts;
-
-  entHasPrepareScript = entHasStageScript "prepare";
-  entHasTestScript    = entHasStageScript "test";
-  entHasPackScript    = ent:
-    lib.libpkginfo.hasPackFromScripts ( ent.scripts or ( getScripts ent ) );
-  entHasPublishScript = ent:
-    lib.libpkginfo.hasPublishFromScripts ( ent.scripts or ( getScripts ent ) );
-  entHasBuildScript = ent:
-    lib.libpkginfo.hasBuildFromScripts ( ent.scripts or ( getScripts ent ) );
-  entHasDepScript = ent: let
-    scripts = ent.scripts or ( getScripts ent );
-  in lib.libpkginfo.hasDepScriptFromScripts scripts;
-  entHasInstallScript = ent: let
-    fromScript = entHasStageScript "install" ent;
-    fromPlock  = ent.hasInstallScript or false;
-  in if lib.libmeta.metaWasPlock ent then fromPlock else fromScript;
-
-
-# ---------------------------------------------------------------------------- #
-
-  # Reconstruct a `metaEnt' from its serialized form.
-  # This performs a small amount of fixup in an effort to support "raw" inputs;
-  # but it is designed for use with `metaEntFrom*' routines that have been
-  # dumped to files.
-  #
-  # If you are "spoofing" a particular type of entry ( ex: `package-lock.json` )
-  # you should refer to the `metaEntFrom*' implementation and real serialized
-  # data to align with it - we do NOT call their actual constructors again and
-  # you cannot rely on any of the impure/inferred values that they normally add.
-  #
-  # XXX: This does not add `entries.*' fields which is important to remember
-  #      particularly for `package-lock.json' entries since you cannot access
-  #      `lockDir', `pkey', or `lockfileVersion' values that are normally
-  #      stashed there - those fields are "really" associated with the `metaSet'
-  #      and the decision to exclude them after serialization is intentional.
-  metaEntFromSerial' = {
-    ifd, pure, allowedPaths, typecheck, basedir ? null
-  } @ fenv: {
-    key         ? ent.ident + "/" + ent.version
-  , ident       ? dirOf ent.key
-  , version     ? baseNameOf ent.key
-  , entFromtype ? "raw"
-  , fetchInfo
-  # These are just here to get `builtins.intersectAttrs' to work.
-  , depInfo   ? {}
-  , sysInfo   ? {}
-  , bin       ? {}
-  , gypfile   ? false  # XXX: do not read this field from registries
-  , lifecycle ? {}
-  , scripts   ? {}
-  , trees     ? {}
-  , hasBin ? lib.libpkginfo.pjsHasBin' ( removeAttrs fenv ["basedir"] ) ent
-  , metaFiles ? {}
+  getGypfile = {
+    metaFiles ? {}
+  , fsInfo    ? null
   , ...
-  } @ ent: let
-    patchFetchInfo =
-      if basedir == null then {} else
-      if ( fetchInfo.type == "path" ) && ( yt.FS.relpath.check fetchInfo.path )
-      then { fetchInfo = fetchInfo // { inherit basedir; }; }
-      else {};
-    members =
-      { inherit ident version entFromtype; } //
-      ( lib.optionalAttrs ( ent ? bin || ent ? hasBin ) {
-        inherit hasBin;
-      } ) // ent // patchFetchInfo;
-    # Use these fallback fields for certain `entFromtype' values.
-    fieldsForFT = {
-      plock = {
-        inherit
-          bin
-          hasBin
-          depInfo
-          sysInfo
-        ;
-      };  # `hasBuild' will be inconclusive for some `git' deps.
-      "package.json" = {
-        inherit
-          bin
-          hasBin
-          scripts
-          depInfo
-          sysInfo
-        ;
-      };
-      # XXX: DO NOT READ `gypfile' field from registries!
-      vinfo = {
-        # TODO: This list is incomplete. See `libreg' for full list of fields.
-        inherit
-          bin
-          scripts
-        ;
-      };
-      # XXX: DO NOT READ `gypfile' field from registries!
-      packument = {
-        # TODO
-      };
-      ylock = {
-        # Fuck this forreal tho.
-        # Probably not going to do this myself.
-      };
-    };
-
-    ftFields = if lib.libmeta.metaWasPlock ent then fieldsForFT.plock else
-               if lib.libmeta.metaWasYlock ent then fieldsForFT.ylock else
-               ( fieldsForFT.${entFromtype} or {} );
-
-  in lib.libmeta.mkMetaEnt ( members // ftFields );
-
-
-# ---------------------------------------------------------------------------- #
-
-  # TODO: enforce `fenv'
-  metaSetFromSerial' = {
-    ifd, pure, allowedPaths, typecheck, basedir ? null
-  } @ fenv: members: let
-    meEnv = {
-      basedir = members._meta.basedir or members._meta.lockDir or
-                members._meta.pjsDir or toString ./.;
-    } // fenv;
-    deserial = name: value: let
-      forEnt = metaEntFromSerial' meEnv value;
-      # Regenerate missing `pjs' and `plock' fields if `lockDir' is defined.
-      # FIXME: this no shouldn't be reading the filesystem without being marked
-      # as "impure" or "ifd".
-      forMeta = ( lib.optionalAttrs ( value ? lockDir ) {
-        pjs   = lib.importJSON' ( value.lockDir + "/package.json" );
-        plock = lib.importJSON' ( value.lockDir + "/package-lock.json" );
-      } ) // value;
-    in if name == "_meta" then forMeta else
-      if lib.hasPrefix "__" name then value else
-      forEnt;
-  in lib.libmeta.mkMetaSet ( builtins.mapAttrs deserial members );
+  } @ ent:
+    metaFiles.pjs.gypfile or
+    ( if fsInfo == null then null else fsInfo.gypfile );
 
 
 # ---------------------------------------------------------------------------- #
@@ -204,12 +72,10 @@
   # ignore extra fields so this is fine ).
   identifyMetaEntFetcherFamily = {
     fetchInfo ? null
-  , ffamily   ? null
   , ...
   } @ metaEnt: let
     plent = ( getMetaFiles metaEnt ).plock or null;
-  in if ffamily != null then ffamily else
-     if fetchInfo != null
+  in if fetchInfo != null
      then lib.libfetch.identifyFetchInfoFetcherFamily fetchInfo else
      if plent != null then lib.libplock.identifyPlentFetcherFamily plent else
      throw "identifyMetaEntFetcherFamily: Cannot discern 'fetcherFamily'";
@@ -232,44 +98,6 @@
 
 # ---------------------------------------------------------------------------- #
 
-  # FIXME: this is pretty dated and out of alignment with `events.nix', as well
-  # as `pkgEnt' and `genMeta'... so basically fucking everything.
-
-  # A nice alternative ( assuming you have applied the lifecycle OV ).
-  # ( metaEnt.hasBin or false ) ||
-  # ( builtins.any ( b: b ) ( builtins.attrValues metaEnt.lifecycle )
-
-  # Determines if a package needs any `node_modules/' to prepare
-  # for consumption.
-  # This framework aims to build projects in isolation, so this helps us
-  # determine which projects actually need processing.
-  # If `hasBuild' is not yet set, we will err on the safe side and assume it
-  # has a build.
-  # XXX: It is strongly recommended that you provide a `hasBuild' field.
-  # For tarballs we know there's no build, but aside from that we don't
-  # make assumptions here.
-  metaEntIsSimple' = { ifd, pure, allowedPaths, typecheck } @ fenv: {
-    hasBuild         ? ( attrs.ltype != "file" ) && ( entHasBuildScript attrs )
-  , hasInstallScript ? entHasInstallScript attrs
-  , hasPrepare       ? entHasPrepareScript attrs
-  , hasTest          ? entHasTestScript attrs
-  , hasBin           ? lib.libpkginfo.pjsHasBin' fenv attrs
-  , ...
-  } @ attrs: ! ( hasBuild || hasInstallScript || hasPrepare || hasBin );
-
-  # Split a collection of packages based on `metaEntIsSimple'.
-  metaSetPartitionSimple' = { ifd, pure, allowedPaths, typecheck } @ fenv: mset:
-    let
-      lst = builtins.attrValues ( mset.__entries or mset );
-      parted = builtins.partition metaEntIsSimple' fenv lst;
-    in {
-      simple       = parted.right;
-      needsModules = parted.wrong;
-    };
-
-
-# ---------------------------------------------------------------------------- #
-
   # `null' means we aren't sure.
   # Input will be normalized to pairs.
   # If `metaEnt' has `directories.bin' we may use IFD in helper routines.
@@ -278,7 +106,7 @@
     getBinPairs = lib.libpkginfo.pjsBinPairs' fenv;
     emptyIsNone = ( lib.libmeta.metaWasPlock ent ) ||
                   ( builtins.elem ent.entFromtype ["package.json" "raw"] );
-    keep  = {
+    keep = {
       ident           = true;
       bin             = true;
       directories.bin = true;
@@ -299,301 +127,9 @@
 
 # ---------------------------------------------------------------------------- #
 
-  # This helper function collects fields used by many `metaEntFrom*' routines
-  # that must be read from the filesystem.
-  # Most importantly it collects a set of available `metaFiles', which can be
-  # used to create an amalgamated `metaEnt' from various inputs.
-  tryCollectMetaFromDir' = { pure, ifd, typecheck, allowedPaths } @ fenv:
-    pathlike: let
-      readAllowed = lib.libread.readAllowed { inherit pure ifd allowedPaths; };
-      checkPl = if typecheck then yt.Typeclasses.pathlike pathlike else
-                pathlike;
-      dir      = lib.coercePath checkPl;
-      isDir    = builtins.pathExists ( dir + "/." );
-      pjs      = lib.importJSONOr null ( dir + "/package.json" );
-      pjsBP    = lib.libpkginfo.pjsBinPairs' fenv;
-      binPairs = if pjs == null then null else
-                 lib.apply pjsBP ( pjs // { _src = pathlike; } );
-      bps'       = if binPairs == null then {} else { bin = binPairs; };
-      sourceInfo = let
-        pp  = lib.generators.toPretty { allowPrettyValues = true; };
-        msg = "tryCollectMetaFromDir: Unsure of how to coerce sourceInfo " +
-              "from value '${pp pathlike}'.";
-        fromString = if yt.FS.Strings.store_path.check pathlike then {
-          outPath = pathlike;
-        } else null;
-      in pathlike.sourceInfo or (
-         if yt.FlocoFetch.source_info_floco.check pathlike then pathlike else
-         if pathlike ? outPath then pathlike else
-         if builtins.isPath pathlike then fromString else
-         if builtins.isString pathlike then fromString else
-         throw msg
-      );
-      sourceInfo' = if sourceInfo != null then { inherit sourceInfo; } else {
-        fetchInfo  = { type = "path"; path = toString pathlike; };
-        sourceInfo = {
-          outPath = builtins.path { recursive = true; path = pathlike; };
-        };
-      };
-      fetchInfo' =
-        if pathlike ? fetchInfo then { inherit (pathlike) fetchInfo; } else {};
-      rsl = if ( readAllowed dir ) && isDir
-            then bps' // sourceInfo' // fetchInfo' // {
-        metaFiles = lib.filterAttrs ( _: v: v != null ) {
-          inherit pjs;
-          plock = lib.importJSONOr null ( dir + "/package-lock.json" );
-          metaJ = lib.importJSONOr null ( dir + "/meta.json" );
-          metaN =
-            if ! ( builtins.pathExists ( dir + "/meta.nix" ) ) then null else
-            import ( dir + "/meta.nix" );
-        };
-        gypfile  = builtins.pathExists ( dir + "/binding.gyp" );
-      } else {};
-      rsl_hit_t = yt.struct {
-        bin        = yt.option ( yt.either yt.PkgInfo.bin_pairs yt.unit );
-        metaFiles  = yt.attrs yt.any;
-        gypfile    = yt.bool;
-        sourceInfo = yt.option yt.FlocoFetch.Eithers.source_info_floco;
-        fetchInfo  = yt.option yt.FlocoFetch.Structs.fetch_info_path;
-      };
-      rslt = yt.either yt.unit rsl_hit_t;
-    in if typecheck then rslt rsl else rsl;
-
-
-# ---------------------------------------------------------------------------- #
-
-  # Returns lists of `metaEnt' records keyed by `<IDENT>/<VERSION>' associated
-  # with any metadata that can be scraped from a directory.
-  #
-  # In practice you'll want to merge this info before using it, but these
-  # unmerged lists are useful for a variety of purposes.
-  #
-  # If you're a regular user, or aren't looking to get into the ugly details of
-  # "how the sausage" is made - you probably want to call `metaSetFromDir'.
-  #
-  # TODO: meta(Ent|Set)Overlays
-  metaSetEntListsFromDir' = { pure, ifd, typecheck, allowedPaths } @ fenv: let
-    inner = pathlike: let
-      msEmpty = lib.libmeta.mkMetaSet {};
-      mfd     = tryCollectMetaFromDir' fenv pathlike;
-      # Exactly like `metaSetFromPlockV3' except we unfuck the `key' field.
-      mkOnePlV3 = pkey: plent: let
-        me = lib.libplock.metaEntFromPlockV3 {
-          lockDir         = toString pathlike;
-          includeTreeInfo = true;
-          inherit pure ifd typecheck allowedPaths;
-          inherit (mfd.metaFiles) plock;
-          inherit (mfd.metaFiles.plock) lockfileVersion;
-        } pkey plent;
-      in me.__update { key = me.ident + "/" + me.version; };
-      # This is a "raw" form of the `metaSetFromPlockV3' routine that doesn't
-      # require unique entries.
-      # In our case we are composing a bunch of entries so we want to work with
-      # a list of entries that do not necessarily need to be unique.
-      mesPl = if ! ( mfd ? metaFiles.plock ) then [] else
-              lib.mapAttrsToList mkOnePlV3 mfd.metaFiles.plock.packages;
-      # Also carries any info scraped from the directory ( `gypfile', etc ).
-      mePjs = let
-        base = lib.libpjs.metaEntFromPjsNoWs' fenv {
-          pjsDir  = toString pathlike;
-          basedir = pathlike.basedir or ( toString pathlike );
-          inherit (mfd.metaFiles) pjs;
-        };
-      in if ! ( mfd ? metaFiles.pjs ) then null else base.__update mfd;
-      mesPjs  = if mePjs == null then [] else [mePjs];
-      meMfRaw = mfd.metaFiles.metaN or mfd.metaFiles.metaJ or null;
-      mesMf   = let
-        fixTree = if ! ( meMfRaw ? _meta.trees ) then meMfRaw else meMfRaw // {
-          ${meMfRaw._meta.rootKey} = meMfRaw.${meMfRaw._meta.rootKey} // {
-            inherit (meMfRaw._meta) trees;
-          };
-        };
-        meEnv = fenv // {
-          basedir = pathlike.basedir or ( toString pathlike );
-        };
-        proc = key: v: lib.metaEntFromSerial' meEnv ( { inherit key; } // v );
-        ents = lib.mapAttrsToList proc ( removeAttrs fixTree ["_meta"] );
-        # `genMeta' writes `_meta.trees.{dev,prod}' which should really be
-        # pushed down into the `rootKey' entry.
-      in if meMfRaw == null then [] else ents;
-
-      allMetaEnts = mesPl ++ mesPjs ++ mesMf;
-      grouped     = builtins.groupBy ( x: x.key ) allMetaEnts;
-      members     = grouped // {
-        _meta = let
-          rootKey =
-            if meMfRaw ? _meta.rootKey then meMfRaw._meta.rootKey else
-            if mfd ? metaFiles.pjs then mePjs.key else
-            if ! ( mfd ? metaFiles.plock ) then null else
-            mfd.metaFiles.plock.name + "/" + mfd.metaFiles.plock.version;
-          rootKey' = if rootKey == null then {} else { inherit rootKey; };
-        in rootKey' // {
-          __serial = lib.libmeta.serialIgnore;
-          fromType = "composite";
-          dir = toString pathlike;
-          inherit (mfd) metaFiles;
-          # TODO: `bin' and `gypfile' fields aren't processed
-          dirInfo = removeAttrs mfd ["metaFiles"];
-        };
-      };
-      ms = lib.libmeta.mkMetaSet members;
-
-      # If we merge entries, we prefer `bin', `hasBin', `ltype', `depInfo',
-      # `hasInstallScript', and `fetchInfo' from `package-lock.json', and
-      # `scripts', `gypfile', `hasBuild', `hasPrepare', `hasPack', `hasPublish',
-      # `hasTest', from `package.json'.
-      # NOTE: `package.json' gets priority on `gypfile' even over
-      # the filesystem!
-      # FIXME: Other routines fuck this ( above NOTE ) up right now.
-      # TODO: After that `meta.{json,nix}' clobbering is something we need to
-      # sort out; but for now I'm giving them priority to act as overrides.
-
-    in if mfd == {} then msEmpty else ms;
-    # TODO: make a real typedef for this.
-    rslt = yt.restrict "metaSet" ( x: ( x._type or null ) == "metaSet" )
-                                 ( yt.attrs yt.any );
-  in if typecheck then yt.defun [yt.Typeclasses.pathlike rslt] inner else inner;
-
-
-# ---------------------------------------------------------------------------- #
-
-  # This is "in broad strokes" the ranking for which metadata sources we trust
-  # over others.
-  # This does NOT speak to the quality of specific fields, and without going
-  # into the implementation details and progress on data normalization for
-  # individual fields/sources - suffice to say this is a generalization.
-  cmpMetaEntFroms = let
-    # 0      ::= "highest priority"/"most trusted"
-    # 999... ::= "total dogshit"/replace with any lower rank option
-    fromTypesRank = {
-      explicit                = 0;   # Assumed to be explitly defined by user.
-      raw                     = 5;
-      "package.json"          = 25;   # Once normalized this is most accurate.
-      srcdir                  = 30;
-      cached                  = 50;
-      "package-lock.json(v2)" = 100;  # Contains more info than v3.
-      "package-lock.json(v3)" = 125;  # Actually "better" than v2, but less info.
-      "package-lock.json(v1)" = 150;  # Only "better" for pinning dep versions.
-      "package-lock.json"     = 200;  # No internal routines mark this.
-      composite               = 300;  # Merged from multiple others
-      # From Registry - this info is often inaccurate
-      vinfo     = 500;   # A specific "abbreviated version" record in Packument.
-      packument = 1000;  # Registry record for all package versions.
-
-      # Not supported/Yarn is garbage and if you're reading this you should
-      # migrate your project away from it.
-      # It poses real security risks and after months of building support for it
-      # in this framework I arrived at the conclusion that, effort aside, it
-      # would be ethically wrong to build any tooling that made Yarn even
-      # remotely more usable than it was in in 2019 - if you or someone you know
-      # is still using Yarn please seek help.
-      #
-      # It may make sense to support Yarn v1; but let me be clear - this tool
-      # was originally designed to support Yarn v2 and v3 BEFORE NPM, and it
-      # was after several months of investigating "why are the
-      # hashes non-deterministic" that I realized that past Yarn v1 the code
-      # quality and security ( particularly regarding checksums ) became
-      # completely inexcusible.
-      # I'll admit that if I read this exact inline comment a few months ago,
-      # I would've said "wow this author sounds like a total crank, come on
-      # how bad could it really be?", to which I'd freely admit "look, I might
-      # be a kook, but I'm not a crank - go read the Yarn v2/3 sources for
-      # generating cache checksums and keys, or read the issue list's responses
-      # to 'why did you reimplement zlib?'".
-      "yarn.lock"     = throw "WARNING: Yarn is bad for your health.";
-      "yarn.lock(v1)" = throw "WARNING: Yarn is bad for your health.";
-      "yarn.lock(v2)" = throw "WARNING: Yarn is bad for your health.";
-      "yarn.lock(v3)" = throw "WARNING: Yarn is bad for your health.";
-      # the number is arbitrary, just ensure that it's always highest.
-      _default = 999;
-    };
-  in a: b:
-     fromTypesRank.${a.entFromType or "_default"} -
-     fromTypesRank.${b.entFromType or "_default"};
-
-  # returns true if "a <= b" or "a is more trusted than b".
-  cmpMetaEntFromsLE = a: b: ( cmpMetaEntFroms a b ) <= 0;
-
-  sortMetaEntriesByRank = builtins.sort cmpMetaEntFromsLE;
-
-
-# ---------------------------------------------------------------------------- #
-
-  # TODO: `bin' and `gypfile' fields aren't recorded in the ent list.
-  # Get the baseline working then figure those out.
-  mergeMetaEntList = ents: let
-    genericFtype = e: let
-      ftype = e.entFromtype;
-    in if ftype == "package.json" then "pjs" else
-       if lib.hasPrefix "package-lock.json" ftype then "plock" else
-       if lib.hasPrefix "yarn.lock" ftype then "ylock" else
-      ftype;
-    # TODO: this is going to break `plock' entries with conflicting instances.
-    byFtype' = builtins.groupBy genericFtype ents;
-    byFtype  = builtins.mapAttrs ( _: es:
-      builtins.foldl' ( me: e: me.__extend ( _: prev:
-        lib.recursiveUpdate e.__entries prev
-      ) ) ( builtins.head es )
-          ( if 1 < ( builtins.length es ) then builtins.tail es else [] )
-    ) byFtype';
-
-    special = {
-      bin = values: let
-        bps = builtins.filter yt.PkgInfo.bin_pairs.check values;
-      in if bps != [] then builtins.head bps else builtins.head values;
-      fetchInfo = values:
-        byFtype.raw.fetchInfo or byFtype.plock.fetchInfo or
-        ( builtins.head values );
-      ltype = values:
-        byFtype.raw.ltype or byFtype.plock.ltype or ( builtins.head values );
-      hasInstallScript = values:
-        byFtype.raw.hasInstallScript or
-        byFtype.plock.hasInstallScript or
-        byFtype.pjs.hasInstallScript or
-        ( builtins.head values );
-      gypfile = values:
-        byFtype.raw.gypfile or byFtype.pjs.gypfile or ( builtins.head values );
-      depInfo = values:
-        byFtype.raw.depInfo or byFtype.plock.depInfo or
-        ( builtins.head values );
-      # preserve early fields, but collect from all
-      metaFiles = builtins.foldl' ( acc: a: a // acc ) {};
-    };
-
-    ranked = sortMetaEntriesByRank ents;
-    zipper = field: values:
-      if special ? ${field} then special.${field} values else
-      builtins.head values;
-    zipped = builtins.zipAttrsWith zipper ( map ( e: e.__entries ) ranked );
-    nents  = builtins.length ents;
-    # TODO: make `composed' `entFromtype'
-  in if nents == 0 then null else
-     if nents == 1 then builtins.head ents else
-     lib.libmeta.mkMetaEnt ( zipped // { entFromtype = "composite"; } );
-
-
-# ---------------------------------------------------------------------------- #
-
-  metaSetFromDir' = { ifd, pure, allowedPaths, typecheck } @ fenv: let
-    inner = pathlike: let
-      lists = metaSetEntListsFromDir' fenv pathlike;
-    in lists.__mapEnts ( _: mergeMetaEntList );
-  in if ! typecheck then inner else
-     yt.defun [yt.Typeclasses.pathlike yt.FlocoMeta.meta_set_shallow] inner;
-
-
-# ---------------------------------------------------------------------------- #
-
   _fenvFns = {
     inherit
-      metaEntFromSerial'
-      metaSetFromSerial'
-      metaEntIsSimple'
-      metaSetPartitionSimple'
       metaEntBinPairs'
-      tryCollectMetaFromDir'
-      metaSetEntListsFromDir'
-      metaSetFromDir'
     ;
   };
 
@@ -602,46 +138,18 @@
 
 in {
   inherit
-    metaEntFromSerial'
-    metaSetFromSerial'
-    metaEntIsSimple'
-    metaSetPartitionSimple'  # by `metaEntIsSimple'
-  ;
-
-  inherit
-    entHasStageScript
-    entHasPrepareScript
-    entHasInstallScript
-    entHasTestScript
-    entHasPackScript
-    entHasBuildScript
-    entHasPublishScript
-    entHasDepScript
-  ;
-
-  inherit
-    identifyLifecycle
-    identifyMetaEntFetcherFamily
-  ;
-
-  inherit
+    getKey
+    getIdent
+    getVersion
+    getEntFromtype
+    getLtype
     getMetaFiles
     getScripts
-  ;
+    getGypfile
 
-  inherit
     metaEntBinPairs'
-  ;
-  inherit
-    tryCollectMetaFromDir'
-    metaSetEntListsFromDir'
-
-    cmpMetaEntFroms
-    cmpMetaEntFromsLE
-    sortMetaEntriesByRank
-
-    mergeMetaEntList
-    metaSetFromDir'
+    identifyMetaEntFetcherFamily
+    identifyLifecycle
   ;
 
   __withFenv = fenv: let

--- a/lib/meta-ent.nix
+++ b/lib/meta-ent.nix
@@ -43,7 +43,8 @@
   # function with custom implementations that fetch these files.
   # TODO: deprecate `entries' field.
   getMetaFiles = { metaFiles ? {}, ... }:
-    yt.FlocoMeta._meta_ent_info_fields.metaFiles metaFiles;
+    yt.FlocoMeta._meta_ent_info_fields.metaFiles
+      ( removeAttrs metaFiles ["__serial"] );
 
   # Abstraction to refer to `package.json' scripts fields.
   getScripts = {
@@ -126,6 +127,19 @@
 
 # ---------------------------------------------------------------------------- #
 
+  genericMetaEnt' = { typecheck, ifd, pure, allowedPaths } @ fenv: members: let
+    base = lib.libmeta.mkMetaEnt members;
+  in base.__extend ( lib.composeManyExtensions [
+    ( lib.libbininfo.binInfoFromMetaFilesOv' {
+        inherit typecheck ifd pure allowedPaths;
+      } )
+    lib.libsys.metaEntSetSysInfoOv
+    lib.libevent.metaEntLifecycleOv
+  ] );
+
+
+# ---------------------------------------------------------------------------- #
+
   # `null' means we aren't sure.
   # Input will be normalized to pairs.
   # If `metaEnt' has `directories.bin' we may use IFD in helper routines.
@@ -159,6 +173,7 @@
     inherit
       metaEntBinPairs'
       metaEntFromRaw'
+      genericMetaEnt'
     ;
   };
 
@@ -176,6 +191,7 @@ in {
     getScripts
     getGypfile
 
+    genericMetaEnt'
     metaEntBinPairs'
     metaEntFromRaw'
     identifyMetaEntFetcherFamily

--- a/lib/meta-ent.nix
+++ b/lib/meta-ent.nix
@@ -82,13 +82,16 @@
   , fsInfo      ? null
   , sourceInfo  ? null
   } @ metaRaw: let
+    # Serialized `binInfo' records may be compressed to `binInfo = false', which
+    # we are responsible for expanding here.
+    binInfo' = if binInfo == false then { binInfo.binPairs = {}; } else {};
     members = {
       # Mandatory fields
       inherit
         key ident version entFromtype ltype fetchInfo depInfo sysInfo lifecycle
       ;
-      metaFiles = { inherit metaRaw; };
-    } // metaRaw;
+      metaFiles = { __serial = lib.libmeta.serialIgnore; inherit metaRaw; };
+    } // metaRaw // binInfo';
     metaEnt = lib.libmeta.mkMetaEnt members;
   in if typecheck then yt.FlocoMeta.meta_ent_info metaEnt else metaEnt;
 

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -383,7 +383,9 @@
   assert ! ( members ? entFromType ); let
     args = { inherit ident version key; } // members;
     core = lib.apply mkMetaEntCore args;
-    base = core.__update members;
+    base = core.__update ( {
+      metaFiles = core.metaFiles // ( members.metaFiles or {} );
+    } // members );
     # Add `names' either as a flat field or recursively.
     withNames = if recNames then base.__extend metaEntExtendWithNames else
                 base.__add ( metaEntNames core );

--- a/lib/overlay.lib.nix
+++ b/lib/overlay.lib.nix
@@ -139,22 +139,11 @@ in {
 
   inherit (final.libmeta)
     toSerial
-    _mkExtInfo
-    mkExtInfo
+    _mkExtInfo mkExtInfo
     metaWasPlock
     metaWasYlock
-
-    mkMetaEnt'
-    mkMetaEnt
+    mkMetaEnt' mkMetaEnt
     mkMetaSet
-
-    genMetaEntAdd
-    genMetaEntUp
-    genMetaEntExtend
-    genMetaEntRules
-
-    metaEntFromSerial'
-    metaSetFromSerial'
   ;
 
   inherit (final.libtree)

--- a/lib/overlay.lib.nix
+++ b/lib/overlay.lib.nix
@@ -59,6 +59,7 @@ in {
   libtree    = callLibs [./tree.nix ./focus-tree.nix];
   libsys     = callLib  ./system.nix;
   libmeta    = callLibs [./meta.nix ./meta-ent.nix ./serial.nix];
+  libbininfo = callLib  ./bin-info.nix;
   libdep     = callLib  ./depinfo.nix;
   libsat     = callLib  ./sat.nix;
   libevent   = callLib  ./events.nix;

--- a/lib/pkg-json.nix
+++ b/lib/pkg-json.nix
@@ -15,16 +15,16 @@
 
   # Standard arg processor that accepts `pjs' or `pjsDir' as an arg used to
   # access `package.json' info.
-  # The arg `wkey' is short for "workspace key", but is currently unused - this
+  # The arg `pjsKey' is short for "workspace key", but is currently unused - this
   # arg is a stub for future workspaces support.
   stdPjsArgProc' = { pure, ifd, typecheck, allowedPaths } @ fenv: self: {
     pjs    ? lib.libpkginfo.readJSONFromPath' fenv ( pjsDir + "/package.json" )
-  , wkey   ? ""
+  , pjsKey   ? ""
   , pjsDir ?
     throw "getIdentPjs: Cannot read workspace members without 'pjsDir'."
   }: let
     loc  = self.__functionMeta.name or "libpjs";
-    args = if wkey == "" then { inherit pjs wkey pjsDir fenv; } else
+    args = if pjsKey == "" then { inherit pjs pjsKey pjsDir fenv; } else
            throw "(${loc}): Reading workspaces has not been implemented.";
     targs = if self ? __thunk then self.__thunk // args else args;
     fargs = if self ? __functionArgs then lib.canPassStrict self targs else
@@ -177,7 +177,7 @@
     raenv = removeAttrs fenv ["typecheck"];
   in {
     pjs    ? lib.libpkginfo.readJSONFromPath' fenv ( pjsDir + "/package.json" )
-  , wkey   ? ""
+  , pjsKey   ? ""
   , pjsDir ?
     throw "getIdentPjs: Cannot read workspace/write fetchInfo without 'pjsDir'."
   , isLocal ? args ? pjsDir
@@ -208,7 +208,7 @@
                            ( "./" + rel );
         };
         type      = "path";
-        path      = assert wkey == "";  pjsDir;
+        path      = assert pjsKey == "";  pjsDir;
         recursive = true;
       };
     };
@@ -255,8 +255,10 @@
         if ( ident == null ) || ( version == null ) then "workspace/0.0.0" else
         ident + "/" + version;
       hasBin    = getHasBinPjs'  fenv gargs;
-      metaFiles = { __serial = lib.libmeta.serialIgnore; inherit pjs wkey; } //
-                  ( if ! ( args ? pjsDir ) then {} else { inherit pjsDir; } );
+      metaFiles = {
+        __serial = lib.libmeta.serialIgnore;
+        inherit pjs pjsKey;
+      } // ( if ! ( args ? pjsDir ) then {} else { inherit pjsDir; } );
       inherit (deps) depInfo;
     } // ( if ( args ? ltype ) || isLocal then { inherit ltype; } else {} )
       // ( if isLocal then forLocal else {} );
@@ -281,7 +283,7 @@
         lib.libevent.metaEntLifecycleOv
       ];
     in if noFs then meta else meta.__extend ov;
-  in if wkey == "" then ex else
+  in if pjsKey == "" then ex else
      throw "getIdentPjs: Reading workspaces has not been implemented.";
 
 

--- a/lib/pkg-json.nix
+++ b/lib/pkg-json.nix
@@ -275,24 +275,10 @@
 
     meta = lib.libmeta.mkMetaEnt infoNoFs;
     ex = let
-      # TODO: this should be a separate overlay made to be general purpose.
-      scriptInfo = final: prev: {
-        hasBuild         = lib.libpkginfo.hasBuildFromScripts final.scripts;
-        hasPrepare       = lib.libpkginfo.hasPrepareFromScripts final.scripts;
-        hasTest          = lib.libpkginfo.hasTestFromScripts final.scripts;
-        hasPack          = lib.libpkginfo.hasPackFromScripts final.scripts;
-        hasPublish       = lib.libpkginfo.hasPublishFromScripts final.scripts;
-        hasInstallScript =
-          if lib.libpkginfo.hasInstallFromScripts final.scripts then true else
-          null;
-      };
-      #ovs = metaEntOverlays or [];
-      #...
       ov = lib.composeManyExtensions [
         ( _: prev: extra // infoFs // prev )
         lib.libsys.metaEntSetSysInfoOv
         lib.libevent.metaEntLifecycleOverlay
-        scriptInfo
       ];
     in if noFs then meta else meta.__extend ov;
   in if wkey == "" then ex else

--- a/lib/pkg-json.nix
+++ b/lib/pkg-json.nix
@@ -278,7 +278,7 @@
       ov = lib.composeManyExtensions [
         ( _: prev: extra // infoFs // prev )
         lib.libsys.metaEntSetSysInfoOv
-        lib.libevent.metaEntLifecycleOverlay
+        lib.libevent.metaEntLifecycleOv
       ];
     in if noFs then meta else meta.__extend ov;
   in if wkey == "" then ex else

--- a/lib/pkg-json.nix
+++ b/lib/pkg-json.nix
@@ -153,11 +153,14 @@
 
 # ---------------------------------------------------------------------------- #
 
-  getIdentPjs'   = fenv: getFieldPjs' fenv { field = "name"; };
-  getVersionPjs' = fenv: getFieldPjs' fenv { field = "version"; };
-  getScriptsPjs' = fenv: getFieldPjs' fenv { field = "scripts"; default = {}; };
+  getIdentPjs' = { ifd, pure, typecheck, allowedPaths } @ fenv:
+    getFieldPjs' fenv { field = "name"; };
+  getVersionPjs' = { ifd, pure, typecheck, allowedPaths } @ fenv:
+    getFieldPjs' fenv { field = "version"; };
+  getScriptsPjs' = { ifd, pure, typecheck, allowedPaths } @ fenv:
+    getFieldPjs' fenv { field = "scripts"; default = {}; };
 
-  getHasBinPjs' = fenv: let
+  getHasBinPjs' = { ifd, pure, typecheck, allowedPaths } @ fenv: let
     getBinFields = getFieldsPjs' fenv {
       fields = { bin = true; directories = true; };
     };

--- a/lib/pkg-lock.nix
+++ b/lib/pkg-lock.nix
@@ -434,7 +434,7 @@
     # FIXME: we are going to merge multiple instances in a really dumb way here
     # until we get this moved into the spec for proper sub-instances.
     metaEntryList = lib.mapAttrsToList mkOne plock.packages;
-    rootKey = ( plock.name or "anon" ) + "/" + ( plock.version or "0.0.0" );
+    rootKey = "${plock.name or "anon"}/${plock.version or "0.0.0-none"}";
     auditKeyValuesUnique = let
       toSerial = e: e.__serial or e;
       toCmp = e: let

--- a/lib/pkg-lock.nix
+++ b/lib/pkg-lock.nix
@@ -389,7 +389,11 @@
       fetchInfo         = lib.libplock.fetchInfoGenericFromPlentV3' fenv
                             { inherit lockDir; } { inherit plentKey plent; };
       metaFiles =
-        if includeTreeInfo then { inherit plent plentKey lockDir; } else {
+        if includeTreeInfo then {
+          __serial = lib.libmeta.serialIgnore;
+          inherit plent plentKey lockDir;
+        } else {
+          __serial = lib.libmeta.serialIgnore;
           inherit lockDir;
           # TODO: this probably is going to blow up for `requires' vs
           # `dependencies' when merging conflicting instances.

--- a/lib/system.nix
+++ b/lib/system.nix
@@ -213,7 +213,9 @@
 # ---------------------------------------------------------------------------- #
 
   metaEntGetSysInfoFromMetaFiles = metaEnt: let
-    mfs = builtins.filter builtins.isAttrs ( lib.libmeta.getMetaFiles metaEnt );
+    mfs  = builtins.filter builtins.isAttrs
+                           ( builtins.attrValues
+                             ( lib.libmeta.getMetaFiles metaEnt ) );
     oss  = builtins.catAttrs "os"      mfs;
     cpus = builtins.catAttrs "cpu"     mfs;
     engs = builtins.catAttrs "engines" mfs;

--- a/pkgs/pkgEnt/mkSrcEnt.nix
+++ b/pkgs/pkgEnt/mkSrcEnt.nix
@@ -152,8 +152,7 @@
       } dir;
     in if readAllowed && isDir then {
       metaFiles = { inherit pjs; };
-      gypfile   = builtins.pathExists ( dir + "/binding.gyp" );
-      scripts   = pjs.scripts or {};
+      fsInfo.gypfile   = builtins.pathExists ( dir + "/binding.gyp" );
     } else {};
 
     # A base `pkgEnt:source' record using our updated `metaEnt'.
@@ -165,7 +164,7 @@
         # Only runs if allowed
         merged = ( metaEnt.__extend ( final: prev:
           lib.recursiveUpdate ( scrape source ) prev
-        ) ).__extend lib.libevent.metaEntLifecycleOverlay;
+        ) ).__extend lib.libevent.metaEntLifecycleOv;
       in if typecheck then yt.FlocoMeta.meta_ent_shallow merged else merged;
     };
   in if ! typecheck then sent else pkg_ent_src sent;

--- a/pkgs/pkgEnt/mkSrcEnt.nix
+++ b/pkgs/pkgEnt/mkSrcEnt.nix
@@ -116,7 +116,7 @@
   _pkg_ent_src_fields = {
     _type = yt.enum "_type[pkgEnt:source]" ["pkgEnt:source"];
     ident = yt.PkgInfo.identifier;
-    inherit (yt.NpmLifecycle.Enums) ltype;
+    inherit (yt.Npm.Enums) ltype;
     inherit (yt.PkgInfo) version key;
     outPath  = yt.FS.store_path;
     tarball  = yt.option yt.FlocoFetch.fetched;

--- a/pkgs/tools/pacote/meta.nix
+++ b/pkgs/tools/pacote/meta.nix
@@ -2586,7 +2586,7 @@
     ident = "pacote";
     key = "pacote/13.3.0";
     ltype = "file";
-    trees = {
+    treeInfo = {
       prod = {
         "node_modules/@gar/promisify" = "@gar/promisify/1.1.3";
         "node_modules/@npmcli/fs" = "@npmcli/fs/2.1.2";

--- a/pkgs/tools/pacote/meta.nix
+++ b/pkgs/tools/pacote/meta.nix
@@ -1,6 +1,8 @@
 {
   "@gar/promisify/1.1.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -10,10 +12,13 @@
     };
     ident = "@gar/promisify";
     key = "@gar/promisify/1.1.3";
+    ltype = "file";
     version = "1.1.3";
   };
   "@npmcli/fs/1.1.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@gar/promisify" = {
         descriptor = "^1.0.1";
@@ -32,10 +37,13 @@
     };
     ident = "@npmcli/fs";
     key = "@npmcli/fs/1.1.1";
+    ltype = "file";
     version = "1.1.1";
   };
   "@npmcli/fs/2.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@gar/promisify" = {
         descriptor = "^1.1.3";
@@ -54,10 +62,13 @@
     };
     ident = "@npmcli/fs";
     key = "@npmcli/fs/2.1.2";
+    ltype = "file";
     version = "2.1.2";
   };
   "@npmcli/git/3.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@npmcli/promise-spawn" = {
         descriptor = "^3.0.0";
@@ -104,11 +115,14 @@
     };
     ident = "@npmcli/git";
     key = "@npmcli/git/3.0.2";
+    ltype = "file";
     version = "3.0.2";
   };
   "@npmcli/installed-package-contents/1.0.7" = {
-    bin = {
-      installed-package-contents = "index.js";
+    binInfo = {
+      binPairs = {
+        installed-package-contents = "index.js";
+      };
     };
     depInfo = {
       npm-bundled = {
@@ -126,13 +140,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz";
     };
-    hasBin = true;
     ident = "@npmcli/installed-package-contents";
     key = "@npmcli/installed-package-contents/1.0.7";
+    ltype = "file";
     version = "1.0.7";
   };
   "@npmcli/move-file/1.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       mkdirp = {
         descriptor = "^1.0.4";
@@ -151,10 +167,13 @@
     };
     ident = "@npmcli/move-file";
     key = "@npmcli/move-file/1.1.2";
+    ltype = "file";
     version = "1.1.2";
   };
   "@npmcli/move-file/2.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       mkdirp = {
         descriptor = "^1.0.4";
@@ -173,10 +192,13 @@
     };
     ident = "@npmcli/move-file";
     key = "@npmcli/move-file/2.0.1";
+    ltype = "file";
     version = "2.0.1";
   };
   "@npmcli/node-gyp/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -186,10 +208,13 @@
     };
     ident = "@npmcli/node-gyp";
     key = "@npmcli/node-gyp/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   "@npmcli/promise-spawn/3.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       infer-owner = {
         descriptor = "^1.0.4";
@@ -204,10 +229,13 @@
     };
     ident = "@npmcli/promise-spawn";
     key = "@npmcli/promise-spawn/3.0.0";
+    ltype = "file";
     version = "3.0.0";
   };
   "@npmcli/run-script/3.0.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@npmcli/node-gyp" = {
         descriptor = "^2.0.0";
@@ -234,10 +262,13 @@
     };
     ident = "@npmcli/run-script";
     key = "@npmcli/run-script/3.0.3";
+    ltype = "file";
     version = "3.0.3";
   };
   "@tootallnate/once/1.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -247,10 +278,13 @@
     };
     ident = "@tootallnate/once";
     key = "@tootallnate/once/1.1.2";
+    ltype = "file";
     version = "1.1.2";
   };
   "@tootallnate/once/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -260,6 +294,7 @@
     };
     ident = "@tootallnate/once";
     key = "@tootallnate/once/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   _meta = {
@@ -267,7 +302,9 @@
     rootKey = "pacote/13.3.0";
   };
   "abbrev/1.1.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -277,10 +314,13 @@
     };
     ident = "abbrev";
     key = "abbrev/1.1.1";
+    ltype = "file";
     version = "1.1.1";
   };
   "agent-base/6.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       debug = {
         descriptor = "4";
@@ -295,10 +335,13 @@
     };
     ident = "agent-base";
     key = "agent-base/6.0.2";
+    ltype = "file";
     version = "6.0.2";
   };
   "agentkeepalive/4.2.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       debug = {
         descriptor = "^4.1.0";
@@ -321,10 +364,13 @@
     };
     ident = "agentkeepalive";
     key = "agentkeepalive/4.2.1";
+    ltype = "file";
     version = "4.2.1";
   };
   "aggregate-error/3.1.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       clean-stack = {
         descriptor = "^2.0.0";
@@ -343,10 +389,13 @@
     };
     ident = "aggregate-error";
     key = "aggregate-error/3.1.0";
+    ltype = "file";
     version = "3.1.0";
   };
   "ansi-regex/5.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -356,10 +405,13 @@
     };
     ident = "ansi-regex";
     key = "ansi-regex/5.0.1";
+    ltype = "file";
     version = "5.0.1";
   };
   "aproba/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -369,10 +421,13 @@
     };
     ident = "aproba";
     key = "aproba/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   "are-we-there-yet/3.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       delegates = {
         descriptor = "^1.0.0";
@@ -391,10 +446,13 @@
     };
     ident = "are-we-there-yet";
     key = "are-we-there-yet/3.0.1";
+    ltype = "file";
     version = "3.0.1";
   };
   "balanced-match/1.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -404,10 +462,13 @@
     };
     ident = "balanced-match";
     key = "balanced-match/1.0.2";
+    ltype = "file";
     version = "1.0.2";
   };
   "brace-expansion/1.1.11" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       balanced-match = {
         descriptor = "^1.0.0";
@@ -426,10 +487,13 @@
     };
     ident = "brace-expansion";
     key = "brace-expansion/1.1.11";
+    ltype = "file";
     version = "1.1.11";
   };
   "brace-expansion/2.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       balanced-match = {
         descriptor = "^1.0.0";
@@ -444,10 +508,13 @@
     };
     ident = "brace-expansion";
     key = "brace-expansion/2.0.1";
+    ltype = "file";
     version = "2.0.1";
   };
   "builtins/5.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       semver = {
         descriptor = "^7.0.0";
@@ -462,10 +529,13 @@
     };
     ident = "builtins";
     key = "builtins/5.0.1";
+    ltype = "file";
     version = "5.0.1";
   };
   "cacache/15.3.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@npmcli/fs" = {
         descriptor = "^1.0.0";
@@ -548,10 +618,13 @@
     };
     ident = "cacache";
     key = "cacache/15.3.0";
+    ltype = "file";
     version = "15.3.0";
   };
   "cacache/16.1.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@npmcli/fs" = {
         descriptor = "^2.1.0";
@@ -634,10 +707,13 @@
     };
     ident = "cacache";
     key = "cacache/16.1.3";
+    ltype = "file";
     version = "16.1.3";
   };
   "chownr/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -647,10 +723,13 @@
     };
     ident = "chownr";
     key = "chownr/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   "clean-stack/2.2.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -660,11 +739,14 @@
     };
     ident = "clean-stack";
     key = "clean-stack/2.2.0";
+    ltype = "file";
     version = "2.2.0";
   };
   "color-support/1.1.3" = {
-    bin = {
-      color-support = "bin.js";
+    binInfo = {
+      binPairs = {
+        color-support = "bin.js";
+      };
     };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
@@ -673,13 +755,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz";
     };
-    hasBin = true;
     ident = "color-support";
     key = "color-support/1.1.3";
+    ltype = "file";
     version = "1.1.3";
   };
   "concat-map/0.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -689,10 +773,13 @@
     };
     ident = "concat-map";
     key = "concat-map/0.0.1";
+    ltype = "file";
     version = "0.0.1";
   };
   "console-control-strings/1.1.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -702,16 +789,20 @@
     };
     ident = "console-control-strings";
     key = "console-control-strings/1.1.0";
+    ltype = "file";
     version = "1.1.0";
   };
   "debug/4.3.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       ms = {
         descriptor = "2.1.2";
         runtime = true;
       };
       supports-color = {
+        peerDescriptor = "*";
         optional = true;
       };
     };
@@ -723,10 +814,13 @@
     };
     ident = "debug";
     key = "debug/4.3.4";
+    ltype = "file";
     version = "4.3.4";
   };
   "delegates/1.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -736,10 +830,13 @@
     };
     ident = "delegates";
     key = "delegates/1.0.0";
+    ltype = "file";
     version = "1.0.0";
   };
   "depd/1.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -749,10 +846,13 @@
     };
     ident = "depd";
     key = "depd/1.1.2";
+    ltype = "file";
     version = "1.1.2";
   };
   "emoji-regex/8.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -762,10 +862,13 @@
     };
     ident = "emoji-regex";
     key = "emoji-regex/8.0.0";
+    ltype = "file";
     version = "8.0.0";
   };
   "encoding/0.1.13" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       iconv-lite = {
         descriptor = "^0.6.2";
@@ -780,10 +883,13 @@
     };
     ident = "encoding";
     key = "encoding/0.1.13";
+    ltype = "file";
     version = "0.1.13";
   };
   "env-paths/2.2.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -793,10 +899,13 @@
     };
     ident = "env-paths";
     key = "env-paths/2.2.1";
+    ltype = "file";
     version = "2.2.1";
   };
   "err-code/2.0.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -806,10 +915,13 @@
     };
     ident = "err-code";
     key = "err-code/2.0.3";
+    ltype = "file";
     version = "2.0.3";
   };
   "fs-minipass/2.1.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.0.0";
@@ -824,10 +936,13 @@
     };
     ident = "fs-minipass";
     key = "fs-minipass/2.1.0";
+    ltype = "file";
     version = "2.1.0";
   };
   "fs.realpath/1.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -837,10 +952,13 @@
     };
     ident = "fs.realpath";
     key = "fs.realpath/1.0.0";
+    ltype = "file";
     version = "1.0.0";
   };
   "function-bind/1.1.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -850,10 +968,13 @@
     };
     ident = "function-bind";
     key = "function-bind/1.1.1";
+    ltype = "file";
     version = "1.1.1";
   };
   "gauge/4.0.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       aproba = {
         descriptor = "^1.0.3 || ^2.0.0";
@@ -896,10 +1017,13 @@
     };
     ident = "gauge";
     key = "gauge/4.0.4";
+    ltype = "file";
     version = "4.0.4";
   };
   "glob/7.2.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "fs.realpath" = {
         descriptor = "^1.0.0";
@@ -934,10 +1058,13 @@
     };
     ident = "glob";
     key = "glob/7.2.3";
+    ltype = "file";
     version = "7.2.3";
   };
   "glob/8.0.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "fs.realpath" = {
         descriptor = "^1.0.0";
@@ -968,10 +1095,13 @@
     };
     ident = "glob";
     key = "glob/8.0.3";
+    ltype = "file";
     version = "8.0.3";
   };
   "graceful-fs/4.2.10" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -981,10 +1111,13 @@
     };
     ident = "graceful-fs";
     key = "graceful-fs/4.2.10";
+    ltype = "file";
     version = "4.2.10";
   };
   "has-unicode/2.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -994,10 +1127,13 @@
     };
     ident = "has-unicode";
     key = "has-unicode/2.0.1";
+    ltype = "file";
     version = "2.0.1";
   };
   "has/1.0.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       function-bind = {
         descriptor = "^1.1.1";
@@ -1012,10 +1148,13 @@
     };
     ident = "has";
     key = "has/1.0.3";
+    ltype = "file";
     version = "1.0.3";
   };
   "hosted-git-info/5.2.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       lru-cache = {
         descriptor = "^7.5.1";
@@ -1030,10 +1169,13 @@
     };
     ident = "hosted-git-info";
     key = "hosted-git-info/5.2.1";
+    ltype = "file";
     version = "5.2.1";
   };
   "http-cache-semantics/4.1.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1043,10 +1185,13 @@
     };
     ident = "http-cache-semantics";
     key = "http-cache-semantics/4.1.0";
+    ltype = "file";
     version = "4.1.0";
   };
   "http-proxy-agent/4.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@tootallnate/once" = {
         descriptor = "1";
@@ -1069,10 +1214,13 @@
     };
     ident = "http-proxy-agent";
     key = "http-proxy-agent/4.0.1";
+    ltype = "file";
     version = "4.0.1";
   };
   "http-proxy-agent/5.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       "@tootallnate/once" = {
         descriptor = "2";
@@ -1095,10 +1243,13 @@
     };
     ident = "http-proxy-agent";
     key = "http-proxy-agent/5.0.0";
+    ltype = "file";
     version = "5.0.0";
   };
   "https-proxy-agent/5.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       agent-base = {
         descriptor = "6";
@@ -1117,10 +1268,13 @@
     };
     ident = "https-proxy-agent";
     key = "https-proxy-agent/5.0.1";
+    ltype = "file";
     version = "5.0.1";
   };
   "humanize-ms/1.2.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       ms = {
         descriptor = "^2.0.0";
@@ -1135,10 +1289,13 @@
     };
     ident = "humanize-ms";
     key = "humanize-ms/1.2.1";
+    ltype = "file";
     version = "1.2.1";
   };
   "iconv-lite/0.6.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       safer-buffer = {
         descriptor = ">= 2.1.2 < 3.0.0";
@@ -1153,10 +1310,13 @@
     };
     ident = "iconv-lite";
     key = "iconv-lite/0.6.3";
+    ltype = "file";
     version = "0.6.3";
   };
   "ignore-walk/5.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minimatch = {
         descriptor = "^5.0.1";
@@ -1171,10 +1331,13 @@
     };
     ident = "ignore-walk";
     key = "ignore-walk/5.0.1";
+    ltype = "file";
     version = "5.0.1";
   };
   "imurmurhash/0.1.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1184,10 +1347,13 @@
     };
     ident = "imurmurhash";
     key = "imurmurhash/0.1.4";
+    ltype = "file";
     version = "0.1.4";
   };
   "indent-string/4.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1197,10 +1363,13 @@
     };
     ident = "indent-string";
     key = "indent-string/4.0.0";
+    ltype = "file";
     version = "4.0.0";
   };
   "infer-owner/1.0.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1210,10 +1379,13 @@
     };
     ident = "infer-owner";
     key = "infer-owner/1.0.4";
+    ltype = "file";
     version = "1.0.4";
   };
   "inflight/1.0.6" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       once = {
         descriptor = "^1.3.0";
@@ -1232,10 +1404,13 @@
     };
     ident = "inflight";
     key = "inflight/1.0.6";
+    ltype = "file";
     version = "1.0.6";
   };
   "inherits/2.0.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1245,10 +1420,13 @@
     };
     ident = "inherits";
     key = "inherits/2.0.4";
+    ltype = "file";
     version = "2.0.4";
   };
   "ip/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1258,10 +1436,13 @@
     };
     ident = "ip";
     key = "ip/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   "is-core-module/2.11.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       has = {
         descriptor = "^1.0.3";
@@ -1276,10 +1457,13 @@
     };
     ident = "is-core-module";
     key = "is-core-module/2.11.0";
+    ltype = "file";
     version = "2.11.0";
   };
   "is-fullwidth-code-point/3.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1289,10 +1473,13 @@
     };
     ident = "is-fullwidth-code-point";
     key = "is-fullwidth-code-point/3.0.0";
+    ltype = "file";
     version = "3.0.0";
   };
   "is-lambda/1.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1302,10 +1489,13 @@
     };
     ident = "is-lambda";
     key = "is-lambda/1.0.1";
+    ltype = "file";
     version = "1.0.1";
   };
   "isexe/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1315,10 +1505,13 @@
     };
     ident = "isexe";
     key = "isexe/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   "json-parse-even-better-errors/2.3.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1328,10 +1521,13 @@
     };
     ident = "json-parse-even-better-errors";
     key = "json-parse-even-better-errors/2.3.1";
+    ltype = "file";
     version = "2.3.1";
   };
   "jsonparse/1.3.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1341,10 +1537,13 @@
     };
     ident = "jsonparse";
     key = "jsonparse/1.3.1";
+    ltype = "file";
     version = "1.3.1";
   };
   "lru-cache/6.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       yallist = {
         descriptor = "^4.0.0";
@@ -1359,10 +1558,13 @@
     };
     ident = "lru-cache";
     key = "lru-cache/6.0.0";
+    ltype = "file";
     version = "6.0.0";
   };
   "lru-cache/7.14.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1372,10 +1574,13 @@
     };
     ident = "lru-cache";
     key = "lru-cache/7.14.0";
+    ltype = "file";
     version = "7.14.0";
   };
   "make-fetch-happen/10.2.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       agentkeepalive = {
         descriptor = "^4.2.1";
@@ -1450,10 +1655,13 @@
     };
     ident = "make-fetch-happen";
     key = "make-fetch-happen/10.2.1";
+    ltype = "file";
     version = "10.2.1";
   };
   "make-fetch-happen/9.1.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       agentkeepalive = {
         descriptor = "^4.1.3";
@@ -1528,10 +1736,13 @@
     };
     ident = "make-fetch-happen";
     key = "make-fetch-happen/9.1.0";
+    ltype = "file";
     version = "9.1.0";
   };
   "minimatch/3.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       brace-expansion = {
         descriptor = "^1.1.7";
@@ -1546,10 +1757,13 @@
     };
     ident = "minimatch";
     key = "minimatch/3.1.2";
+    ltype = "file";
     version = "3.1.2";
   };
   "minimatch/5.1.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       brace-expansion = {
         descriptor = "^2.0.1";
@@ -1564,10 +1778,13 @@
     };
     ident = "minimatch";
     key = "minimatch/5.1.0";
+    ltype = "file";
     version = "5.1.0";
   };
   "minipass-collect/1.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.0.0";
@@ -1582,10 +1799,13 @@
     };
     ident = "minipass-collect";
     key = "minipass-collect/1.0.2";
+    ltype = "file";
     version = "1.0.2";
   };
   "minipass-fetch/1.4.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       encoding = {
         descriptor = "^0.1.12";
@@ -1613,10 +1833,13 @@
     };
     ident = "minipass-fetch";
     key = "minipass-fetch/1.4.1";
+    ltype = "file";
     version = "1.4.1";
   };
   "minipass-fetch/2.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       encoding = {
         descriptor = "^0.1.13";
@@ -1644,10 +1867,13 @@
     };
     ident = "minipass-fetch";
     key = "minipass-fetch/2.1.2";
+    ltype = "file";
     version = "2.1.2";
   };
   "minipass-flush/1.0.5" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.0.0";
@@ -1662,10 +1888,13 @@
     };
     ident = "minipass-flush";
     key = "minipass-flush/1.0.5";
+    ltype = "file";
     version = "1.0.5";
   };
   "minipass-json-stream/1.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       jsonparse = {
         descriptor = "^1.3.1";
@@ -1684,10 +1913,13 @@
     };
     ident = "minipass-json-stream";
     key = "minipass-json-stream/1.0.1";
+    ltype = "file";
     version = "1.0.1";
   };
   "minipass-pipeline/1.2.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.0.0";
@@ -1702,10 +1934,13 @@
     };
     ident = "minipass-pipeline";
     key = "minipass-pipeline/1.2.4";
+    ltype = "file";
     version = "1.2.4";
   };
   "minipass-sized/1.0.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.0.0";
@@ -1720,10 +1955,13 @@
     };
     ident = "minipass-sized";
     key = "minipass-sized/1.0.3";
+    ltype = "file";
     version = "1.0.3";
   };
   "minipass/3.3.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       yallist = {
         descriptor = "^4.0.0";
@@ -1738,10 +1976,13 @@
     };
     ident = "minipass";
     key = "minipass/3.3.4";
+    ltype = "file";
     version = "3.3.4";
   };
   "minizlib/2.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.0.0";
@@ -1760,11 +2001,14 @@
     };
     ident = "minizlib";
     key = "minizlib/2.1.2";
+    ltype = "file";
     version = "2.1.2";
   };
   "mkdirp/1.0.4" = {
-    bin = {
-      mkdirp = "bin/cmd.js";
+    binInfo = {
+      binPairs = {
+        mkdirp = "bin/cmd.js";
+      };
     };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
@@ -1773,13 +2017,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz";
     };
-    hasBin = true;
     ident = "mkdirp";
     key = "mkdirp/1.0.4";
+    ltype = "file";
     version = "1.0.4";
   };
   "ms/2.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1789,10 +2035,13 @@
     };
     ident = "ms";
     key = "ms/2.1.2";
+    ltype = "file";
     version = "2.1.2";
   };
   "negotiator/0.6.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1802,11 +2051,14 @@
     };
     ident = "negotiator";
     key = "negotiator/0.6.3";
+    ltype = "file";
     version = "0.6.3";
   };
   "node-gyp/8.4.1" = {
-    bin = {
-      node-gyp = "bin/node-gyp.js";
+    binInfo = {
+      binPairs = {
+        node-gyp = "bin/node-gyp.js";
+      };
     };
     depInfo = {
       env-paths = {
@@ -1856,14 +2108,16 @@
       type = "tarball";
       url = "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz";
     };
-    hasBin = true;
     ident = "node-gyp";
     key = "node-gyp/8.4.1";
+    ltype = "file";
     version = "8.4.1";
   };
   "nopt/5.0.0" = {
-    bin = {
-      nopt = "bin/nopt.js";
+    binInfo = {
+      binPairs = {
+        nopt = "bin/nopt.js";
+      };
     };
     depInfo = {
       abbrev = {
@@ -1877,13 +2131,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz";
     };
-    hasBin = true;
     ident = "nopt";
     key = "nopt/5.0.0";
+    ltype = "file";
     version = "5.0.0";
   };
   "normalize-package-data/4.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       hosted-git-info = {
         descriptor = "^5.0.0";
@@ -1910,10 +2166,13 @@
     };
     ident = "normalize-package-data";
     key = "normalize-package-data/4.0.1";
+    ltype = "file";
     version = "4.0.1";
   };
   "npm-bundled/1.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       npm-normalize-package-bin = {
         descriptor = "^1.0.1";
@@ -1928,10 +2187,13 @@
     };
     ident = "npm-bundled";
     key = "npm-bundled/1.1.2";
+    ltype = "file";
     version = "1.1.2";
   };
   "npm-bundled/2.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       npm-normalize-package-bin = {
         descriptor = "^2.0.0";
@@ -1946,10 +2208,13 @@
     };
     ident = "npm-bundled";
     key = "npm-bundled/2.0.1";
+    ltype = "file";
     version = "2.0.1";
   };
   "npm-install-checks/5.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       semver = {
         descriptor = "^7.1.1";
@@ -1964,10 +2229,13 @@
     };
     ident = "npm-install-checks";
     key = "npm-install-checks/5.0.0";
+    ltype = "file";
     version = "5.0.0";
   };
   "npm-normalize-package-bin/1.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1977,10 +2245,13 @@
     };
     ident = "npm-normalize-package-bin";
     key = "npm-normalize-package-bin/1.0.1";
+    ltype = "file";
     version = "1.0.1";
   };
   "npm-normalize-package-bin/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -1990,10 +2261,13 @@
     };
     ident = "npm-normalize-package-bin";
     key = "npm-normalize-package-bin/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   "npm-package-arg/9.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       hosted-git-info = {
         descriptor = "^5.0.0";
@@ -2020,11 +2294,14 @@
     };
     ident = "npm-package-arg";
     key = "npm-package-arg/9.1.2";
+    ltype = "file";
     version = "9.1.2";
   };
   "npm-packlist/5.1.3" = {
-    bin = {
-      npm-packlist = "bin/index.js";
+    binInfo = {
+      binPairs = {
+        npm-packlist = "bin/index.js";
+      };
     };
     depInfo = {
       glob = {
@@ -2050,13 +2327,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.1.3.tgz";
     };
-    hasBin = true;
     ident = "npm-packlist";
     key = "npm-packlist/5.1.3";
+    ltype = "file";
     version = "5.1.3";
   };
   "npm-pick-manifest/7.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       npm-install-checks = {
         descriptor = "^5.0.0";
@@ -2083,10 +2362,13 @@
     };
     ident = "npm-pick-manifest";
     key = "npm-pick-manifest/7.0.2";
+    ltype = "file";
     version = "7.0.2";
   };
   "npm-registry-fetch/13.3.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       make-fetch-happen = {
         descriptor = "^10.0.6";
@@ -2125,10 +2407,13 @@
     };
     ident = "npm-registry-fetch";
     key = "npm-registry-fetch/13.3.1";
+    ltype = "file";
     version = "13.3.1";
   };
   "npmlog/6.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       are-we-there-yet = {
         descriptor = "^3.0.0";
@@ -2155,10 +2440,13 @@
     };
     ident = "npmlog";
     key = "npmlog/6.0.2";
+    ltype = "file";
     version = "6.0.2";
   };
   "once/1.4.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       wrappy = {
         descriptor = "1";
@@ -2173,10 +2461,13 @@
     };
     ident = "once";
     key = "once/1.4.0";
+    ltype = "file";
     version = "1.4.0";
   };
   "p-map/4.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       aggregate-error = {
         descriptor = "^3.0.0";
@@ -2191,11 +2482,14 @@
     };
     ident = "p-map";
     key = "p-map/4.0.0";
+    ltype = "file";
     version = "4.0.0";
   };
   "pacote/13.3.0" = {
-    bin = {
-      pacote = "lib/bin.js";
+    binInfo = {
+      binPairs = {
+        pacote = "lib/bin.js";
+      };
     };
     depInfo = {
       "@npmcli/git" = {
@@ -2289,9 +2583,9 @@
       type = "tarball";
       url = "https://registry.npmjs.org/pacote/-/pacote-13.3.0.tgz";
     };
-    hasBin = true;
     ident = "pacote";
     key = "pacote/13.3.0";
+    ltype = "file";
     trees = {
       prod = {
         "node_modules/@gar/promisify" = "@gar/promisify/1.1.3";
@@ -2446,7 +2740,9 @@
     version = "13.3.0";
   };
   "path-is-absolute/1.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2456,10 +2752,13 @@
     };
     ident = "path-is-absolute";
     key = "path-is-absolute/1.0.1";
+    ltype = "file";
     version = "1.0.1";
   };
   "proc-log/2.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2469,10 +2768,13 @@
     };
     ident = "proc-log";
     key = "proc-log/2.0.1";
+    ltype = "file";
     version = "2.0.1";
   };
   "promise-inflight/1.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2482,10 +2784,13 @@
     };
     ident = "promise-inflight";
     key = "promise-inflight/1.0.1";
+    ltype = "file";
     version = "1.0.1";
   };
   "promise-retry/2.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       err-code = {
         descriptor = "^2.0.2";
@@ -2504,10 +2809,13 @@
     };
     ident = "promise-retry";
     key = "promise-retry/2.0.1";
+    ltype = "file";
     version = "2.0.1";
   };
   "read-package-json-fast/2.0.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       json-parse-even-better-errors = {
         descriptor = "^2.3.0";
@@ -2526,10 +2834,13 @@
     };
     ident = "read-package-json-fast";
     key = "read-package-json-fast/2.0.3";
+    ltype = "file";
     version = "2.0.3";
   };
   "read-package-json/5.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       glob = {
         descriptor = "^8.0.1";
@@ -2556,10 +2867,13 @@
     };
     ident = "read-package-json";
     key = "read-package-json/5.0.2";
+    ltype = "file";
     version = "5.0.2";
   };
   "readable-stream/3.6.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       inherits = {
         descriptor = "^2.0.3";
@@ -2582,10 +2896,13 @@
     };
     ident = "readable-stream";
     key = "readable-stream/3.6.0";
+    ltype = "file";
     version = "3.6.0";
   };
   "retry/0.12.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2595,11 +2912,14 @@
     };
     ident = "retry";
     key = "retry/0.12.0";
+    ltype = "file";
     version = "0.12.0";
   };
   "rimraf/3.0.2" = {
-    bin = {
-      rimraf = "bin.js";
+    binInfo = {
+      binPairs = {
+        rimraf = "bin.js";
+      };
     };
     depInfo = {
       glob = {
@@ -2613,13 +2933,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz";
     };
-    hasBin = true;
     ident = "rimraf";
     key = "rimraf/3.0.2";
+    ltype = "file";
     version = "3.0.2";
   };
   "safe-buffer/5.2.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2629,10 +2951,13 @@
     };
     ident = "safe-buffer";
     key = "safe-buffer/5.2.1";
+    ltype = "file";
     version = "5.2.1";
   };
   "safer-buffer/2.1.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2642,11 +2967,14 @@
     };
     ident = "safer-buffer";
     key = "safer-buffer/2.1.2";
+    ltype = "file";
     version = "2.1.2";
   };
   "semver/7.3.8" = {
-    bin = {
-      semver = "bin/semver.js";
+    binInfo = {
+      binPairs = {
+        semver = "bin/semver.js";
+      };
     };
     depInfo = {
       lru-cache = {
@@ -2660,13 +2988,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz";
     };
-    hasBin = true;
     ident = "semver";
     key = "semver/7.3.8";
+    ltype = "file";
     version = "7.3.8";
   };
   "set-blocking/2.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2676,10 +3006,13 @@
     };
     ident = "set-blocking";
     key = "set-blocking/2.0.0";
+    ltype = "file";
     version = "2.0.0";
   };
   "signal-exit/3.0.7" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2689,10 +3022,13 @@
     };
     ident = "signal-exit";
     key = "signal-exit/3.0.7";
+    ltype = "file";
     version = "3.0.7";
   };
   "smart-buffer/4.2.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2702,10 +3038,13 @@
     };
     ident = "smart-buffer";
     key = "smart-buffer/4.2.0";
+    ltype = "file";
     version = "4.2.0";
   };
   "socks-proxy-agent/6.2.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       agent-base = {
         descriptor = "^6.0.2";
@@ -2728,10 +3067,13 @@
     };
     ident = "socks-proxy-agent";
     key = "socks-proxy-agent/6.2.1";
+    ltype = "file";
     version = "6.2.1";
   };
   "socks-proxy-agent/7.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       agent-base = {
         descriptor = "^6.0.2";
@@ -2754,10 +3096,13 @@
     };
     ident = "socks-proxy-agent";
     key = "socks-proxy-agent/7.0.0";
+    ltype = "file";
     version = "7.0.0";
   };
   "socks/2.7.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       ip = {
         descriptor = "^2.0.0";
@@ -2776,10 +3121,13 @@
     };
     ident = "socks";
     key = "socks/2.7.1";
+    ltype = "file";
     version = "2.7.1";
   };
   "spdx-correct/3.1.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       spdx-expression-parse = {
         descriptor = "^3.0.0";
@@ -2798,10 +3146,13 @@
     };
     ident = "spdx-correct";
     key = "spdx-correct/3.1.1";
+    ltype = "file";
     version = "3.1.1";
   };
   "spdx-exceptions/2.3.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2811,10 +3162,13 @@
     };
     ident = "spdx-exceptions";
     key = "spdx-exceptions/2.3.0";
+    ltype = "file";
     version = "2.3.0";
   };
   "spdx-expression-parse/3.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       spdx-exceptions = {
         descriptor = "^2.1.0";
@@ -2833,10 +3187,13 @@
     };
     ident = "spdx-expression-parse";
     key = "spdx-expression-parse/3.0.1";
+    ltype = "file";
     version = "3.0.1";
   };
   "spdx-license-ids/3.0.12" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -2846,10 +3203,13 @@
     };
     ident = "spdx-license-ids";
     key = "spdx-license-ids/3.0.12";
+    ltype = "file";
     version = "3.0.12";
   };
   "ssri/8.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.1.1";
@@ -2864,10 +3224,13 @@
     };
     ident = "ssri";
     key = "ssri/8.0.1";
+    ltype = "file";
     version = "8.0.1";
   };
   "ssri/9.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       minipass = {
         descriptor = "^3.1.1";
@@ -2882,10 +3245,13 @@
     };
     ident = "ssri";
     key = "ssri/9.0.1";
+    ltype = "file";
     version = "9.0.1";
   };
   "string-width/4.2.3" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       emoji-regex = {
         descriptor = "^8.0.0";
@@ -2908,10 +3274,13 @@
     };
     ident = "string-width";
     key = "string-width/4.2.3";
+    ltype = "file";
     version = "4.2.3";
   };
   "string_decoder/1.3.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       safe-buffer = {
         descriptor = "~5.2.0";
@@ -2926,10 +3295,13 @@
     };
     ident = "string_decoder";
     key = "string_decoder/1.3.0";
+    ltype = "file";
     version = "1.3.0";
   };
   "strip-ansi/6.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       ansi-regex = {
         descriptor = "^5.0.1";
@@ -2944,10 +3316,13 @@
     };
     ident = "strip-ansi";
     key = "strip-ansi/6.0.1";
+    ltype = "file";
     version = "6.0.1";
   };
   "tar/6.1.12" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       chownr = {
         descriptor = "^2.0.0";
@@ -2982,10 +3357,13 @@
     };
     ident = "tar";
     key = "tar/6.1.12";
+    ltype = "file";
     version = "6.1.12";
   };
   "unique-filename/1.1.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       unique-slug = {
         descriptor = "^2.0.0";
@@ -3000,10 +3378,13 @@
     };
     ident = "unique-filename";
     key = "unique-filename/1.1.1";
+    ltype = "file";
     version = "1.1.1";
   };
   "unique-filename/2.0.1" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       unique-slug = {
         descriptor = "^3.0.0";
@@ -3018,10 +3399,13 @@
     };
     ident = "unique-filename";
     key = "unique-filename/2.0.1";
+    ltype = "file";
     version = "2.0.1";
   };
   "unique-slug/2.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       imurmurhash = {
         descriptor = "^0.1.4";
@@ -3036,10 +3420,13 @@
     };
     ident = "unique-slug";
     key = "unique-slug/2.0.2";
+    ltype = "file";
     version = "2.0.2";
   };
   "unique-slug/3.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       imurmurhash = {
         descriptor = "^0.1.4";
@@ -3054,10 +3441,13 @@
     };
     ident = "unique-slug";
     key = "unique-slug/3.0.0";
+    ltype = "file";
     version = "3.0.0";
   };
   "util-deprecate/1.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -3067,10 +3457,13 @@
     };
     ident = "util-deprecate";
     key = "util-deprecate/1.0.2";
+    ltype = "file";
     version = "1.0.2";
   };
   "validate-npm-package-license/3.0.4" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       spdx-correct = {
         descriptor = "^3.0.0";
@@ -3089,10 +3482,13 @@
     };
     ident = "validate-npm-package-license";
     key = "validate-npm-package-license/3.0.4";
+    ltype = "file";
     version = "3.0.4";
   };
   "validate-npm-package-name/4.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       builtins = {
         descriptor = "^5.0.0";
@@ -3107,11 +3503,14 @@
     };
     ident = "validate-npm-package-name";
     key = "validate-npm-package-name/4.0.0";
+    ltype = "file";
     version = "4.0.0";
   };
   "which/2.0.2" = {
-    bin = {
-      node-which = "bin/node-which";
+    binInfo = {
+      binPairs = {
+        node-which = "bin/node-which";
+      };
     };
     depInfo = {
       isexe = {
@@ -3125,13 +3524,15 @@
       type = "tarball";
       url = "https://registry.npmjs.org/which/-/which-2.0.2.tgz";
     };
-    hasBin = true;
     ident = "which";
     key = "which/2.0.2";
+    ltype = "file";
     version = "2.0.2";
   };
   "wide-align/1.1.5" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = {
       string-width = {
         descriptor = "^1.0.2 || 2 || 3 || 4";
@@ -3146,10 +3547,13 @@
     };
     ident = "wide-align";
     key = "wide-align/1.1.5";
+    ltype = "file";
     version = "1.1.5";
   };
   "wrappy/1.0.2" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -3159,10 +3563,13 @@
     };
     ident = "wrappy";
     key = "wrappy/1.0.2";
+    ltype = "file";
     version = "1.0.2";
   };
   "yallist/4.0.0" = {
-    bin = { };
+    binInfo = {
+      binPairs = { };
+    };
     depInfo = { };
     entFromtype = "package-lock.json(v3)";
     fetchInfo = {
@@ -3172,6 +3579,7 @@
     };
     ident = "yallist";
     key = "yallist/4.0.0";
+    ltype = "file";
     version = "4.0.0";
   };
 }

--- a/pkgs/tools/pacote/pacote.nix
+++ b/pkgs/tools/pacote/pacote.nix
@@ -60,7 +60,7 @@
   # already, or they might be a mix of keys and `pkgEnt' - so this routine
   # ensures all keys are converted to packages.
   pkgTree = let
-    tree     = args.tree or metaSet.${metaSet._meta.rootKey}.trees.prod;
+    tree     = args.tree or metaSet.${metaSet._meta.rootKey}.treeInfo.prod;
     treeDone = builtins.all ( x: x ? outPath ) ( builtins.attrValues tree );
     fallback = builtins.mapAttrs ( nmPath: key: pkgSet.${key} ) tree;
   in if treeDone then tree else fallback;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -24,7 +24,7 @@
 
 , keepFailed  ? false  # Useful if you run the test explicitly.
 , doTrace     ? true   # We want this disabled for `nix flake check'
-, limit       ? 100    # Limits the max dataset for certain tests.
+, limit       ? null   # Limits the max dataset for certain tests.
                        # Generally subdirs raise their limit.
 , ...
 } @ args: let
@@ -35,7 +35,7 @@
   auto = let
     flocoScrape' = if pure || ( ! ifd ) then {} else { inherit flocoScrape; };
   in {
-    inherit lib pkgsFor;
+    inherit lib pkgsFor system;
 
     inherit limit;
 
@@ -72,6 +72,7 @@
     ./types
     ./libtree
     ./libevent
+    ./types
     # Derivations
     ./mkNmDir
     ./pkg-set

--- a/tests/libevent/tests.nix
+++ b/tests/libevent/tests.nix
@@ -23,21 +23,20 @@
     };
   };
 
-  mefsStrict = lib.libmeta.metaEntFromSerial' {
-    ifd = false; pure = true; allowedPaths = []; typecheck = true;
-  };
-  mefsLc = m: ( mefsStrict m ).__extend lib.libevent.metaEntLifecycleOverlay;
+  mefsLc = m:
+    ( lib.libmeta.mkMetaEnt m ).__extend lib.libevent.metaEntLifecycleOverlay;
 
 
 # ---------------------------------------------------------------------------- #
 
   tests = {
 
-    data = {
+    env = {
       inherit
         metaRaw
       ;
     };
+
 
 # ---------------------------------------------------------------------------- #
 

--- a/tests/libevent/tests.nix
+++ b/tests/libevent/tests.nix
@@ -23,13 +23,6 @@
     };
   };
 
-  metaRaw_lfi0  = metaRaw // { lifecycle.install = false; };
-  metaRaw_lfi1  = metaRaw // { lifecycle.install = true; };
-  metaRaw_lfb   = metaRaw // { ltype = "dir"; lifecycle.build = false; };
-  metaRaw_lfmfi = metaRaw // { metaFiles.plock.hasInstallScript = true; };
-  metaRaw_lfhi  = metaRaw // { hasInstallScript = true; };
-  metaRaw_lfmfs = metaRaw // { metaFiles.pjs.scripts.preinstall = ":"; };
-
   mefsStrict = lib.libmeta.metaEntFromSerial' {
     ifd = false; pure = true; allowedPaths = []; typecheck = true;
   };
@@ -43,19 +36,13 @@
     data = {
       inherit
         metaRaw
-        metaRaw_lfi0
-        metaRaw_lfi1
-        metaRaw_lfb
-        metaRaw_lfmfi
-        metaRaw_lfhi
-        metaRaw_lfmfs
       ;
     };
 
 # ---------------------------------------------------------------------------- #
 
     testPartialLc_lodash_Deserial_0 = {
-      expr = ( mefsLc metaRaw_lfi0 ).lifecycle;
+      expr = ( mefsLc ( metaRaw // { lifecycle.install = false; } ) ).lifecycle;
       expected = {
         build   = false;
         prepare = false;
@@ -67,7 +54,7 @@
     };
 
     testPartialLc_lodash_Deserial_1 = {
-      expr = ( mefsLc metaRaw_lfi1 ).lifecycle;
+      expr = ( mefsLc ( metaRaw // { lifecycle.install = true; } ) ).lifecycle;
       expected = {
         build   = false;
         prepare = false;
@@ -79,7 +66,10 @@
     };
 
     testPartialLc_lodash_Deserial_2 = {
-      expr = ( mefsLc metaRaw_lfb ).lifecycle;
+      expr = ( mefsLc ( metaRaw // {
+        ltype           = "dir";
+        lifecycle.build = false;
+      } ) ).lifecycle;
       expected = {
         build   = false;
         prepare = false;
@@ -91,7 +81,9 @@
     };
 
     testPartialLc_lodash_Deserial_3 = {
-      expr = ( mefsLc metaRaw_lfmfi ).lifecycle;
+      expr = ( mefsLc ( metaRaw // {
+        metaFiles.plock.hasInstallScript = true;
+      } ) ).lifecycle;
       expected = {
         build   = false;
         prepare = false;
@@ -103,19 +95,9 @@
     };
 
     testPartialLc_lodash_Deserial_4 = {
-      expr = ( mefsLc metaRaw_lfhi ).lifecycle;
-      expected = {
-        build   = false;
-        prepare = false;
-        pack    = false;
-        test    = false;
-        publish = false;
-        install = true;
-      };
-    };
-
-    testPartialLc_lodash_Deserial_5 = {
-      expr = ( mefsLc metaRaw_lfmfs ).lifecycle;
+      expr = ( mefsLc ( metaRaw // {
+        metaFiles.pjs.scripts.preinstall = ":";
+      } ) ).lifecycle;
       expected = {
         build   = false;
         prepare = false;

--- a/tests/libevent/tests.nix
+++ b/tests/libevent/tests.nix
@@ -8,43 +8,54 @@
 
 # ---------------------------------------------------------------------------- #
 
-  data = {
-
-    partialLcRaw = {
-      "lodash/4.17.21" = {
-        ident             = "lodash";
-        version           = "4.17.21";
-        key               = "lodash/4.17.21";
-        ltype             = "file";
-        entFromtype       = "package.json";
-        lifecycle.install = false;
-        depInfo           = {};
-        sysInfo           = {};
-        fetchInfo         = {
-          type    = "tarball";
-          url     = "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz";
-          narHash = "sha256-amyN064Yh6psvOfLgcpktd5dRNQStUYHHoIqiI6DMek=";
-        };
-      };
-    };  # End Partial
-
-    partialLcMe_lodash = lib.libmeta.metaEntFromSerial' {
-      ifd = false; pure = true; allowedPaths = []; typecheck = false;
-    } data.partialLcRaw."lodash/4.17.21";
-
+  metaRaw = {
+    ident             = "lodash";
+    version           = "4.17.21";
+    key               = "lodash/4.17.21";
+    ltype             = "file";
+    entFromtype       = "package.json";
+    depInfo           = {};
+    sysInfo           = {};
+    fetchInfo         = {
+      type    = "tarball";
+      url     = "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz";
+      narHash = "sha256-amyN064Yh6psvOfLgcpktd5dRNQStUYHHoIqiI6DMek=";
+    };
   };
+
+  metaRaw_lfi0  = metaRaw // { lifecycle.install = false; };
+  metaRaw_lfi1  = metaRaw // { lifecycle.install = true; };
+  metaRaw_lfb   = metaRaw // { ltype = "dir"; lifecycle.build = false; };
+  metaRaw_lfmfi = metaRaw // { metaFiles.plock.hasInstallScript = true; };
+  metaRaw_lfhi  = metaRaw // { hasInstallScript = true; };
+  metaRaw_lfmfs = metaRaw // { metaFiles.pjs.scripts.preinstall = ":"; };
+
+  mefsStrict = lib.libmeta.metaEntFromSerial' {
+    ifd = false; pure = true; allowedPaths = []; typecheck = true;
+  };
+  mefsLc = m: ( mefsStrict m ).__extend lib.libevent.metaEntLifecycleOverlay;
+
 
 # ---------------------------------------------------------------------------- #
 
   tests = {
 
+    data = {
+      inherit
+        metaRaw
+        metaRaw_lfi0
+        metaRaw_lfi1
+        metaRaw_lfb
+        metaRaw_lfmfi
+        metaRaw_lfhi
+        metaRaw_lfmfs
+      ;
+    };
+
 # ---------------------------------------------------------------------------- #
 
-    testPartialLc_lodash_Deserial = {
-      expr = let
-        me =
-          data.partialLcMe_lodash.__extend lib.libevent.metaEntLifecycleOverlay;
-      in me.lifecycle;
+    testPartialLc_lodash_Deserial_0 = {
+      expr = ( mefsLc metaRaw_lfi0 ).lifecycle;
       expected = {
         build   = false;
         prepare = false;
@@ -54,6 +65,67 @@
         install = false;
       };
     };
+
+    testPartialLc_lodash_Deserial_1 = {
+      expr = ( mefsLc metaRaw_lfi1 ).lifecycle;
+      expected = {
+        build   = false;
+        prepare = false;
+        pack    = false;
+        test    = false;
+        publish = false;
+        install = true;
+      };
+    };
+
+    testPartialLc_lodash_Deserial_2 = {
+      expr = ( mefsLc metaRaw_lfb ).lifecycle;
+      expected = {
+        build   = true;
+        prepare = false;
+        pack    = false;
+        test    = false;
+        publish = false;
+        install = false;
+      };
+    };
+
+    testPartialLc_lodash_Deserial_3 = {
+      expr = ( mefsLc metaRaw_lfmfi ).lifecycle;
+      expected = {
+        build   = false;
+        prepare = false;
+        pack    = false;
+        test    = false;
+        publish = false;
+        install = true;
+      };
+    };
+
+    testPartialLc_lodash_Deserial_4 = {
+      expr = ( mefsLc metaRaw_lfhi ).lifecycle;
+      expected = {
+        build   = false;
+        prepare = false;
+        pack    = false;
+        test    = false;
+        publish = false;
+        install = true;
+      };
+    };
+
+    testPartialLc_lodash_Deserial_5 = {
+      expr = ( mefsLc metaRaw_lfmfs ).lifecycle;
+      expected = {
+        build   = false;
+        prepare = false;
+        pack    = false;
+        test    = false;
+        publish = false;
+        install = true;
+      };
+    };
+
 
 # ---------------------------------------------------------------------------- #
 

--- a/tests/libevent/tests.nix
+++ b/tests/libevent/tests.nix
@@ -24,7 +24,7 @@
   };
 
   mefsLc = m:
-    ( lib.libmeta.mkMetaEnt m ).__extend lib.libevent.metaEntLifecycleOverlay;
+    ( lib.libmeta.mkMetaEnt m ).__extend lib.libevent.metaEntLifecycleOv;
 
 
 # ---------------------------------------------------------------------------- #
@@ -44,10 +44,6 @@
       expr = ( mefsLc ( metaRaw // { lifecycle.install = false; } ) ).lifecycle;
       expected = {
         build   = false;
-        prepare = false;
-        pack    = false;
-        test    = false;
-        publish = false;
         install = false;
       };
     };
@@ -56,10 +52,6 @@
       expr = ( mefsLc ( metaRaw // { lifecycle.install = true; } ) ).lifecycle;
       expected = {
         build   = false;
-        prepare = false;
-        pack    = false;
-        test    = false;
-        publish = false;
         install = true;
       };
     };
@@ -71,24 +63,16 @@
       } ) ).lifecycle;
       expected = {
         build   = false;
-        prepare = false;
-        pack    = false;
-        test    = false;
-        publish = false;
-        install = false;
+        install = null;
       };
     };
 
     testPartialLc_lodash_Deserial_3 = {
       expr = ( mefsLc ( metaRaw // {
-        metaFiles.plock.hasInstallScript = true;
+        metaFiles.plent.hasInstallScript = true;
       } ) ).lifecycle;
       expected = {
         build   = false;
-        prepare = false;
-        pack    = false;
-        test    = false;
-        publish = false;
         install = true;
       };
     };
@@ -99,10 +83,6 @@
       } ) ).lifecycle;
       expected = {
         build   = false;
-        prepare = false;
-        pack    = false;
-        test    = false;
-        publish = false;
         install = true;
       };
     };

--- a/tests/libevent/tests.nix
+++ b/tests/libevent/tests.nix
@@ -81,7 +81,7 @@
     testPartialLc_lodash_Deserial_2 = {
       expr = ( mefsLc metaRaw_lfb ).lifecycle;
       expected = {
-        build   = true;
+        build   = false;
         prepare = false;
         pack    = false;
         test    = false;

--- a/tests/libmeta/tests.nix
+++ b/tests/libmeta/tests.nix
@@ -1,0 +1,113 @@
+# ============================================================================ #
+#
+# General tests for `libmeta' routines.
+#
+# ---------------------------------------------------------------------------- #
+
+{ lib } @ args: let
+
+  yt = lib.ytypes;
+
+# ---------------------------------------------------------------------------- #
+
+  # Minimal `metaEnt' from "raw" info.
+  # Omitting any of these fields from should result in an error.
+  # NOTE: `key' is omitted because it is derived from `ident' and `version'.
+  metaRaw = {
+    ident       = "lodash";
+    version     = "4.17.21";
+    ltype       = "file";
+    entFromtype = "package.json";
+    depInfo     = {};
+    sysInfo     = {};
+    lifecycle   = { install = false; build = false; };
+    fetchInfo   = {
+      type    = "tarball";
+      url     = "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz";
+      narHash = "sha256-amyN064Yh6psvOfLgcpktd5dRNQStUYHHoIqiI6DMek=";
+    };
+  };
+  metaEnt = lib.libmeta.mkMetaEnt metaRaw;
+
+# ---------------------------------------------------------------------------- #
+
+  tests = {
+    env = {
+      inherit args lib metaRaw metaEnt;
+    };
+
+# ---------------------------------------------------------------------------- #
+
+    testMkMetaEnt_0 = {
+      expr        = yt.FlocoMeta.meta_ent_info.checkType metaEnt;
+      expected.ok = true;
+    };
+
+    # Check that `key' can be derived from `ident' + `version'.
+    testMkMetaEnt_1 = {
+      expr = let
+        m = ( removeAttrs metaRaw ["ident" "version"] ) // {
+          key = metaRaw.ident + "/" + metaRaw.version;
+        };
+      in yt.FlocoMeta.meta_ent_info.checkType ( lib.libmeta.mkMetaEnt m );
+      expected.ok = true;
+    };
+
+
+# ---------------------------------------------------------------------------- #
+
+    testGetKey_0 = {
+      expr     = lib.libmeta.getKey metaEnt;
+      expected = "lodash/4.17.21";
+    };
+
+    testGetIdent_0 = {
+      expr     = lib.libmeta.getIdent metaEnt;
+      expected = "lodash";
+    };
+
+    testGetVersion_0 = {
+      expr     = lib.libmeta.getVersion metaEnt;
+      expected = "4.17.21";
+    };
+
+    testGetEntFromtype_0 = {
+      expr     = lib.libmeta.getEntFromtype metaEnt;
+      expected = "raw";
+    };
+
+    testGetLtype_0 = {
+      expr     = lib.libmeta.getLtype metaEnt;
+      expected = "file";
+    };
+
+    testGetMetaFiles_0 = {
+      expr     = lib.libmeta.getMetaFiles metaEnt;
+      expected = {};
+    };
+
+    testGetScripts_0 = {
+      expr     = lib.libmeta.getScripts metaEnt;
+      expected = null;
+    };
+
+    testGetGypfile_0 = {
+      expr     = lib.libmeta.getGypfile metaEnt;
+      expected = null;
+    };
+
+
+# ---------------------------------------------------------------------------- #
+
+  };  # End Tests
+
+# ---------------------------------------------------------------------------- #
+
+in tests
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/tests/libmeta/tests.nix
+++ b/tests/libmeta/tests.nix
@@ -73,7 +73,7 @@
 
     testGetEntFromtype_0 = {
       expr     = lib.libmeta.getEntFromtype metaEnt;
-      expected = "raw";
+      expected = "package.json";
     };
 
     testGetLtype_0 = {

--- a/tests/types/default.nix
+++ b/tests/types/default.nix
@@ -14,7 +14,7 @@
 , writeText   ? pkgsFor.writeText
 , keepFailed  ? false  # Useful if you run the test explicitly.
 , doTrace     ? true   # We want this disabled for `nix flake check'
-, limit       ? 1000
+, limit       ? null
 , ...
 } @ args: let
 

--- a/types/fetched.nix
+++ b/types/fetched.nix
@@ -112,7 +112,7 @@ in {
 
   Structs.fetched = yt.struct "fetched" {
     _type      = yt.restrict "_type[fetched]" ( s: s == "fetched" ) yt.string;
-    ltype      = yt.option yt.NpmLifecycle.Enums.ltype;
+    ltype      = yt.option yt.Npm.Enums.ltype;
     ffamily    = yt.FlocoFetch.Enums.fetcher_family;
     outPath    = yt.FS.store_path;
     fetchInfo  = yt.FlocoFetch.Eithers.fetch_info_floco;

--- a/types/meta.nix
+++ b/types/meta.nix
@@ -154,6 +154,44 @@
 
 # ---------------------------------------------------------------------------- #
 
+  Structs.tree_info = yt.struct "tree_info" {
+    prod = yt.option ( yt.attrs yt.PkgInfo.key );
+    dev  = yt.option ( yt.attrs yt.PkgInfo.key );
+  };
+
+
+# ---------------------------------------------------------------------------- #
+
+  Structs.filesystem_info = yt.struct "filesystem_info" {
+    gypfile = yt.bool;
+    dir     = yt.FS.relpath;
+  };
+
+
+# ---------------------------------------------------------------------------- #
+
+  _meta_files_info_fields = {
+    pjsDir       = yt.FS.abspath;
+    lockDir      = yt.FS.abspath;
+    vinfoUrl     = yt.Uri.Strings.uri_ref;
+    packumentUrl = yt.Uri.Strings.uri_ref;
+    metaRaw      = yt.attrs yt.any;
+    pjs          = yt.attrs yt.any;
+    plock        = yt.NpmLock.plock_shallow;
+    plent        = yt.NpmLock.package;
+    plentKey     = yt.NpmLock.pkey;
+    vinfo        = yt.Packument.vinfo_meta;
+    packument    = yt.Packument.packument;
+    trees        = yt.FlocoMeta.Structs.tree_info;
+  };
+
+  Structs.meta_files_info =
+    yt.struct "meta_files_info"
+      ( builtins.mapAttrs ( _: yt.option ) yt.FlocoMeta._meta_files_fields );
+
+
+# ---------------------------------------------------------------------------- #
+
   _meta_ent_info_fields = {
     inherit (yt.PkgInfo) key version;
     ident       = yt.PkgInfo.identifier;
@@ -164,10 +202,10 @@
     fetchInfo  = yt.FlocoFetch.fetch_info_type_floco;
     sourceInfo = yt.FlocoFetch.source_info_floco;
     sysInfo    = yt.Npm.sys_info;
-    treeInfo   = /* TODO */ yt.attrs yt.any;
-    lifecycle  = /* TODO */ yt.attrs yt.bool;
-    fsInfo     = /* TODO */ yt.attrs yt.any;
-    metaFiles  = /* TODO */ yt.attrs yt.any;
+    inherit (yt.Npm) lifecycle;
+    treeInfo   = yt.FlocoMeta.Structs.tree_info;
+    fsInfo     = yt.FlocoMeta.Structs.filesystem_info;
+    metaFiles  = yt.FlocoMeta.Structs.meta_files_info;
   };
 
 
@@ -192,6 +230,9 @@ in {
   ;
   inherit (Structs)
     bin_info
+    tree_info
+    filesystem_info
+    meta_files_info
   ;
 
   inherit
@@ -202,6 +243,7 @@ in {
     _plock_fromtypes
     _ylock_fromtypes
     _bin_info_fields
+    _meta_files_info_fields
     _meta_ent_info_fields
   ;
 

--- a/types/meta.nix
+++ b/types/meta.nix
@@ -125,11 +125,61 @@
 
 # ---------------------------------------------------------------------------- #
 
+  _bin_info_fields = {
+    binPairs = yt.PkgInfo.bin_pairs;
+    binDir   = yt.FS.relpath;
+  };
+
+  Structs.bin_info_raw = yt.struct "bin_info" {
+    binPairs = yt.option _bin_info_fields.binPairs;
+    binDir   = yt.option _bin_info_fields.binDir;
+  };
+
+  Structs.bin_info = typedef' {
+    name      = "bin_info";
+    checkType = v: let
+      raw     = yt.FlocoMeta.Structs.bin_info_raw.checkType v;
+      base    = if raw.ok then removeAttrs raw ["err"] else raw;
+      hasAtLeastOne = let
+        ok   = ( v ? binPairs ) || ( v ? binDir );
+        err' = if ok then {} else {
+          err =
+            "expected 'bin_info', but value '${yt.__internal.prettyPrint v}' " +
+            "lacks either a 'binPairs' or 'binDir' field.";
+        };
+      in if raw.ok then { inherit ok; } // err' else {};
+    in base // hasAtLeastOne // { ok = raw.ok && hasAtLeastOne.ok; };
+  };
+
+
+# ---------------------------------------------------------------------------- #
+
+  _meta_ent_info_fields = {
+    inherit (yt.PkgInfo) key version;
+    ident       = yt.PkgInfo.identifier;
+    entFromType = yt.FlocoMeta.Enums.meta_fromtype;
+    inherit (ytypes.Npm.Enums) ltype;
+    binInfo    = yt.FlocoMeta.Structs.bin_info;
+    depInfo    = yt.DepInfo.dep_info;
+    fetchInfo  = yt.FlocoFetch.fetch_info_type_floco;
+    sourceInfo = yt.FlocoFetch.source_info_floco;
+    sysInfo    = yt.Npm.sys_info;
+    treeInfo   = /* TODO */ yt.attrs yt.any;
+    lifecycle  = /* TODO */ yt.attrs yt.bool;
+    fsInfo     = /* TODO */ yt.attrs yt.any;
+    metaFiles  = /* TODO */ yt.attrs yt.any;
+  };
+
+
+
+# ---------------------------------------------------------------------------- #
+
 in {
   inherit
     Enums
     Attrs
     Typeclasses
+    Structs
   ;
   inherit (Typeclasses)
     meta_ext
@@ -140,6 +190,9 @@ in {
     meta_ent_shallow
     meta_set_shallow
   ;
+  inherit (Structs)
+    bin_info
+  ;
 
   inherit
     _meta_ext_fields
@@ -148,7 +201,10 @@ in {
     _meta_fromtypes
     _plock_fromtypes
     _ylock_fromtypes
+    _bin_info_fields
+    _meta_ent_info_fields
   ;
+
 }
 
 

--- a/types/meta.nix
+++ b/types/meta.nix
@@ -130,6 +130,10 @@
     binDir   = yt.FS.relpath;
   };
 
+  # NOTE: serialized form may be compressed as:
+  #   binInfo = false;
+  # Implying:
+  #   binInfo.binPairs = {};
   Structs.bin_info_raw = yt.struct "bin_info" {
     binPairs = yt.option _bin_info_fields.binPairs;
     binDir   = yt.option _bin_info_fields.binDir;
@@ -178,6 +182,7 @@
     packumentUrl = yt.Uri.Strings.uri_ref;
     metaRaw      = yt.attrs yt.any;
     pjs          = yt.attrs yt.any;
+    pjsKey       = yt.FS.relpath;
     plock        = yt.NpmLock.plock_shallow;
     plent        = yt.NpmLock.package;
     plentKey     = yt.NpmLock.pkey;

--- a/types/npm/default.nix
+++ b/types/npm/default.nix
@@ -1,0 +1,29 @@
+# ============================================================================ #
+#
+# Merges type sub-modules into full `ytypes.Npm' collection.
+#
+# ---------------------------------------------------------------------------- #
+
+{ ytypes }: let
+
+  merges = [
+    "Attrs" "Enums" "Structs" "Eithers" "Strings" "Sums" "Typeclasses"
+  ];
+
+  proc = tm: acc: f:
+    if builtins.elem f merges then acc // {
+      ${f} = ( acc.${f} or {} ) // tm.${f};
+    } else acc // { ${f} = tm.${f}; };
+
+  typeModules = [./lifecycle.nix ./system.nix];
+
+in builtins.foldl' ( acc: tp: let
+     tm = import tp { inherit ytypes; };
+   in builtins.foldl' ( proc tm ) acc ( builtins.attrNames tm )
+) {} typeModules
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/types/npm/lifecycle.nix
+++ b/types/npm/lifecycle.nix
@@ -386,6 +386,24 @@ in {
 
 # ---------------------------------------------------------------------------- #
 
+  # For `metaEnt'
+  lifecycle = yt.__internal.typedef' {
+    name = "lifecycle_info";
+    checkType = v: let
+      raw       = ( yt.attrs yt.bool ).checkType v;
+      base      = if raw.ok then removeAttrs raw ["err"] else raw;
+      mandatory = ( v ? install ) && ( v ? build );
+      mandErr   =
+        "expected 'lifecycle_info', but value '${yt.__internal.prettyPrint v}' "
+        + "lacks required field(s): 'install' and 'build'.";
+      err' = if ! raw.ok then { inherit (raw) err; } else
+             if ! mandatory then { err = mandErr; } else {};
+    in { ok = raw.ok && mandatory; } // err';
+  };
+
+
+# ---------------------------------------------------------------------------- #
+
 }
 
 

--- a/types/npm/lifecycle.nix
+++ b/types/npm/lifecycle.nix
@@ -390,7 +390,7 @@ in {
   lifecycle = yt.__internal.typedef' {
     name = "lifecycle_info";
     checkType = v: let
-      raw       = ( yt.attrs yt.bool ).checkType v;
+      raw       = ( yt.attrs ( yt.either yt.nil yt.bool ) ).checkType v;
       base      = if raw.ok then removeAttrs raw ["err"] else raw;
       mandatory = ( v ? install ) && ( v ? build );
       mandErr   =

--- a/types/npm/lifecycle.nix
+++ b/types/npm/lifecycle.nix
@@ -56,7 +56,7 @@
 { ytypes }: let
 
   yt  = ytypes // ytypes.Core // ytypes.Prim;
-  nlc = yt.NpmLifecycle // yt.NpmLifecycle.Enums;
+  nlc = yt.Npm // yt.Npm.Enums;
 
 # ---------------------------------------------------------------------------- #
 
@@ -71,7 +71,7 @@ in {
   Enums.source_type =
     yt.enum "npm:lifecycle:source_type" nlc._source_types;
 
-  Enums.ltype = yt.NpmLifecycle.Enums.source_type;
+  Enums.ltype = yt.Npm.Enums.source_type;
 
 
 # ---------------------------------------------------------------------------- #

--- a/types/npm/system.nix
+++ b/types/npm/system.nix
@@ -1,0 +1,67 @@
+# ============================================================================ #
+#
+#
+#
+# ---------------------------------------------------------------------------- #
+
+{ ytypes }: let
+
+  yt = ytypes // ytypes.Core // ytypes.Prim;
+  inherit (yt) struct string list attrs option restrict;
+  lib.test = patt: s: ( builtins.match patt s ) != null;
+
+# ---------------------------------------------------------------------------- #
+  _npm_cpus = [
+    "x64" "ia32" "arm" "arm64" "s390x" "ppc64" "mips64el" "riscv64" "loong64"
+    "unknown"
+  ];
+  Enums.npm_cpu = yt.enum "cpu[npm]" _npm_cpus;
+
+
+  _npm_oss = [
+    "darwin" "freebsd" "netbsd" "linux" "openbsd" "sunos" "sunos-64" "solaris"
+    "win32" "aix" "android" "unknown"
+  ];
+  Enums.npm_os = yt.enum "os[npm]" _npm_oss;
+
+
+# ---------------------------------------------------------------------------- #
+
+  Attrs.engines = yt.attrs yt.PkgInfo.descriptor;
+
+
+# ---------------------------------------------------------------------------- #
+
+  _sys_info_fields = {
+    cpu = yt.list yt.Npm.Enums.npm_cpu;
+    os  = yt.list yt.Npm.Enums.npm_os;
+    inherit (yt.Npm.Attrs) engines;
+  };
+
+  Structs.sys_info =
+    yt.struct "sys_info" ( builtins.mapAttrs yt.option _sys_info_fields );
+
+
+# ---------------------------------------------------------------------------- #
+
+in {
+  inherit
+    Enums
+    Structs
+    Attrs
+  ;
+  inherit (Structs)
+    sys_info
+  ;
+  inherit
+    _npm_cpus
+    _npm_oss
+    _sys_info_fields
+  ;
+}
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/types/npm/system.nix
+++ b/types/npm/system.nix
@@ -39,7 +39,8 @@
   };
 
   Structs.sys_info =
-    yt.struct "sys_info" ( builtins.mapAttrs yt.option _sys_info_fields );
+    yt.struct "sys_info" ( builtins.mapAttrs ( _: yt.option )
+                                             _sys_info_fields );
 
 
 # ---------------------------------------------------------------------------- #

--- a/types/overlay.yt.nix
+++ b/types/overlay.yt.nix
@@ -5,7 +5,7 @@
 # ---------------------------------------------------------------------------- #
 
 final: prev: {
-  NpmLifecycle = import ./npm/lifecycle.nix { ytypes = final; };
+  Npm          = import ./npm               { ytypes = final; };
   NpmLock      = import ./npm-lock.nix      { ytypes = final; };
   Packument    = import ./packument.nix     { ytypes = final; };
   PkgInfo      = import ./pkginfo.nix       { ytypes = final; };


### PR DESCRIPTION
- kills `meta(Ent|Set)FromSerial`
  - TODO: scrub docs
- adds `metaEntFromRaw`
- `metaEnt` is now a strict set of fields.
  - adds: `binInfo`, `fsInfo`, `treeInfo`, adds new `metaFiles` fields.
- Most overlays became sensitive to ordering.
  - This basically blows a hole in the approach to treating `metaEnt` as a recursively defined set; but honestly since the fields are strict now there's really a valid reason to `rec`.